### PR TITLE
Implemented suggestions from Justin

### DIFF
--- a/build_config.json
+++ b/build_config.json
@@ -1,10 +1,10 @@
 {
   "app_name" : "mux",
   "default_roku_user" : "rokudev",
-  "default_roku_target" : "192.168.1.242",
+  "default_roku_target" : "192.168.5.119",
   "default_roku_pass" : "rokudev",
   "app_name" : "mux",
   "build_dir_name" : "build",
   "out_dir_name" : "out",
-  "sample_app_type" : "recycle_video"
+  "sample_app_type" : "reset_video"
 }

--- a/build_config.json
+++ b/build_config.json
@@ -1,10 +1,10 @@
 {
   "app_name" : "mux",
   "default_roku_user" : "rokudev",
-  "default_roku_target" : "192.168.5.119",
+  "default_roku_target" : "192.168.1.242",
   "default_roku_pass" : "rokudev",
   "app_name" : "mux",
   "build_dir_name" : "build",
   "out_dir_name" : "out",
-  "sample_app_type" : "reset_video" 
+  "sample_app_type" : "recycle_video"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,10 +37,10 @@ gulp.task('deploy', ['closeApp', 'cleanup', 'build_sample_app','build_components
   var roku_ip = (env_roku_ip == undefined) ? buildConfig.default_roku_target : env_roku_ip
   var roku_user = (env_roku_user == undefined) ? buildConfig.default_roku_user : env_roku_user
   var roku_pass = (env_roku_pass == undefined) ? buildConfig.default_roku_pass : env_roku_pass
-  console.debug("Deploying to device IP: " + roku_ip + " (" + roku_user + " | " + roku_pass + ")")
+  console.log("Deploying to device IP: " + roku_ip + " (" + roku_user + " | " + roku_pass + ")")
 
-  var curlCommand = "curl --user " + roku_user + ":" + roku_pass 
-                    + " --digest --show-error -F 'mysubmit=Install' -F 'archive=@" + buildConfig.out_dir_name + "/" + buildConfig.app_name 
+  var curlCommand = "curl --user " + roku_user + ":" + roku_pass
+                    + " --digest --show-error -F 'mysubmit=Install' -F 'archive=@" + buildConfig.out_dir_name + "/" + buildConfig.app_name
                     + ".zip' --output /tmp/dev_server_out --write-out '%{http_code}' http://" + roku_ip + "/plugin_install"
   console.log("curlCommand:"+curlCommand)
   var response = exec(curlCommand)
@@ -73,10 +73,10 @@ gulp.task('deploy_test', ['closeApp', 'cleanup', 'build_sample_app', 'package_te
   var roku_ip = (env_roku_ip == undefined) ? buildConfig.default_roku_target : env_roku_ip
   var roku_user = (env_roku_user == undefined) ? buildConfig.default_roku_user : env_roku_user
   var roku_pass = (env_roku_pass == undefined) ? buildConfig.default_roku_pass : env_roku_pass
-  console.debug("Deploying to device IP: " + roku_ip + " (" + roku_user + " | " + roku_pass + ")")
+  console.log("Deploying to device IP: " + roku_ip + " (" + roku_user + " | " + roku_pass + ")")
 
-  var curlCommand = "curl --user " + roku_user + ":" + roku_pass 
-                    + " --digest --show-error -F 'mysubmit=Install' -F 'archive=@" + buildConfig.out_dir_name + "/" + buildConfig.app_name + "-tests" 
+  var curlCommand = "curl --user " + roku_user + ":" + roku_pass
+                    + " --digest --show-error -F 'mysubmit=Install' -F 'archive=@" + buildConfig.out_dir_name + "/" + buildConfig.app_name + "-tests"
                     + ".zip' --output /tmp/dev_server_out --write-out '%{http_code}' http://" + roku_ip + "/plugin_install"
   // console.log("curlCommand:"+curlCommand)
   var response = exec(curlCommand)

--- a/sampleapp_source/components_recycled/components/VideoScene.brs
+++ b/sampleapp_source/components_recycled/components/VideoScene.brs
@@ -68,7 +68,7 @@ function setContent(selectionId as String)
         m.muxConfig.video_variant_name = "BB1"
         m.muxConfig.video_variant_id = "BUNNY_ID"
         m.muxConfig.current_audio_track = "customer set audio track 1"
-        m.muxConfig.current_subtitle_track = "customer set subtitle track 1"
+        m.muxConfig.video_source_current_subtitle_track = "customer set subtitle track 1"
         m.mux.setField("config", m.muxConfig)
     else if selectionId = "2"
         contentNode.URL= "http://video.ted.com/talks/podcast/DavidKelley_2002_480.mp4"
@@ -82,8 +82,8 @@ function setContent(selectionId as String)
         m.muxConfig.video_cdn = "cdn2"
         m.muxConfig.video_variant_name = "TED1"
         m.muxConfig.video_variant_id = "TED_ID"
-        m.muxConfig.current_audio_track = "customer set audio track 2"
-        m.muxConfig.current_subtitle_track = "customer set subtitle track 2"
+        m.muxConfig.video_source_current_audio_track = "customer set audio track 2"
+        m.muxConfig.video_source_current_subtitle_track = "customer set subtitle track 2"
         m.mux.setField("config", m.muxConfig)
     else if selectionId = "3"
         contentNode.URL= "https://content.jwplatform.com/manifests/yp34SRmf.m3u8"
@@ -99,7 +99,7 @@ function setContent(selectionId as String)
         m.muxConfig.video_variant_name = "CY1"
         m.muxConfig.video_variant_id = "Cycling_ID"
         m.muxConfig.current_audio_track = "customer set audio track 3"
-        m.muxConfig.current_subtitle_track = "customer set subtitle track 3"
+        m.muxConfig.video_source_current_audio_track = "customer set subtitle track 3"
         m.mux.setField("config", m.muxConfig)
     end if
     m.video.content = contentNode

--- a/sampleapp_source/components_recycled/components/VideoScene.brs
+++ b/sampleapp_source/components_recycled/components/VideoScene.brs
@@ -4,10 +4,10 @@ function init()
   m.facade = m.top.FindNode("adFacade")
   m.list = m.top.FindNode("MenuList")
   m.video = m.top.FindNode("MainVideo")
- 
-  ' SETUP MUX 
+
+  ' SETUP MUX
   m.muxConfig = {
-    property_key: "794c4b2668e515963d9de4623",
+    property_key: "<YOUR PROPERTY KEY>",
     player_name: "Recycle Player",
     player_version: "1.0.0"
   }
@@ -40,7 +40,7 @@ function init()
   end for
   m.list.content = listContent
   m.list.observeField("itemSelected", "onItemSelected")
-  m.list.setFocus(true) 
+  m.list.setFocus(true)
 end function
 
 
@@ -67,7 +67,7 @@ function setContent(selectionId as String)
         m.muxConfig.video_cdn = "cdn1"
         m.muxConfig.video_variant_name = "BB1"
         m.muxConfig.video_variant_id = "BUNNY_ID"
-        m.muxConfig.current_audio_track = "customer set audio track 1"
+        m.muxConfig.video_source_current_audio_track = "customer set audio track 1"
         m.muxConfig.video_source_current_subtitle_track = "customer set subtitle track 1"
         m.mux.setField("config", m.muxConfig)
     else if selectionId = "2"
@@ -98,8 +98,8 @@ function setContent(selectionId as String)
         m.muxConfig.video_cdn = "cdn3"
         m.muxConfig.video_variant_name = "CY1"
         m.muxConfig.video_variant_id = "Cycling_ID"
-        m.muxConfig.current_audio_track = "customer set audio track 3"
-        m.muxConfig.video_source_current_audio_track = "customer set subtitle track 3"
+        m.muxConfig.video_source_current_audio_track = "customer set audio track 3"
+        m.muxConfig.video_source_current_subtitle_track = "customer set subtitle track 3"
         m.mux.setField("config", m.muxConfig)
     end if
     m.video.content = contentNode

--- a/sampleapp_source/components_reset/components/VideoScene.brs
+++ b/sampleapp_source/components_reset/components/VideoScene.brs
@@ -2,9 +2,9 @@ function init()
   m.top.backgroundURI = ""
   m.top.backgroundColor="0x111111FF"
   m.video = m.top.FindNode("MainVideo")
-  
+
   muxConfig = {
-    property_key: "794c4b2668e515963d9de4623",
+    property_key: "<YOUR PROPERTY KEY>",
     player_name: "Reset Player"
   }
   m.mux = m.top.FindNode("mux")
@@ -15,7 +15,7 @@ function init()
   m.list.wrapDividerBitmapUri = ""
   setupContent()
   m.list.observeField("itemSelected", "onItemSelected")
-  m.list.setFocus(true) 
+  m.list.setFocus(true)
 end function
 
 function setupContent()
@@ -34,23 +34,23 @@ function setupContent()
         },
         {
           title: "Stitched Ad",
-          selectionID: "stitched" 
+          selectionID: "stitched"
         },
         {
           title: "Error before playback",
-          selectionID: "preplaybackerror" 
+          selectionID: "preplaybackerror"
         },
         {
           title: "Error during playback",
-          selectionID: "playbackerror" 
+          selectionID: "playbackerror"
         },
         {
           title: "HLS stream no ads",
-          selectionID: "hlsnoads" 
+          selectionID: "hlsnoads"
         },
         {
           title: "DASH stream no ads",
-          selectionID: "dashnoads" 
+          selectionID: "dashnoads"
         }
     ]
     listContent = createObject("roSGNode","ContentNode")
@@ -72,7 +72,7 @@ function onItemSelected()
     m.loadingText.text = menuItemTitle
     m.loading.visible = true
     m.loading.setFocus(true)
- 
+
     'Run task to playback with RAF
     m.PlayerTask = CreateObject("roSGNode", "PlayerTask")
     m.PlayerTask.observeField("state", "taskStateChanged")

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -179,6 +179,7 @@ function muxAnalytics() as Object
 
   prototype.MUX_SDK_VERSION = ""
   prototype.PLAYER_SOFTWARE_NAME = "RokuSG"
+  prototype.MUX_API_VERSION = "2.0"
   prototype.PLAYER_IS_FULLSCREEN = "true"
 
   prototype.init = function(connection as Object, port as Object, appInfo as Object, systemConfig as Object, customerConfig as Object, hbt as Object, pp as Object)
@@ -723,6 +724,12 @@ function muxAnalytics() as Object
     props.player_software_version = Mid(deviceInfo.GetVersion(), 3, 4)
     props.player_model_number = deviceInfo.GetModel()
     props.player_mux_plugin_name = appInfo.GetTitle()
+    props.viewer_application_name = "Roku"
+    props.viewer_application_version = Mid(deviceInfo.GetVersion(), 3, 4)
+    props.viewer_device_name = "Roku"
+    props.viewer_os_family = "Roku"
+    props.viewer_os_version = Mid(deviceInfo.GetVersion(), 3, 4)
+    props.mux_api_version = m.MUX_API_VERSION
     props.player_version = appInfo.GetVersion()
     props.player_mux_plugin_version = m.MUX_SDK_VERSION
     props.player_country_code = deviceInfo.GetCountryCode()
@@ -804,7 +811,7 @@ function muxAnalytics() as Object
         props.video_source_mime_type = m._getStreamFormat(content.URL)
       end if
 
-      props._videoSourceFormat = m._getVideoFormat(content.URL)
+      m._videoSourceFormat = m._getVideoFormat(content.URL)
 
       if content.Live <> Invalid
         if content.Live = true
@@ -881,7 +888,6 @@ function muxAnalytics() as Object
     end if
     if m._viewTimeToFirstFrame <> Invalid AND m._viewTimeToFirstFrame <> 0
       props.view_time_to_first_frame = m._viewTimeToFirstFrame.toStr()
-      props.view_aggregate_startup_time = m._viewTimeToFirstFrame.toStr()
     end if
     if m._contentPlaybackTime <> Invalid AND m._contentPlaybackTime <> 0
       props.view_content_playback_time = m._contentPlaybackTime.toStr()
@@ -925,6 +931,9 @@ function muxAnalytics() as Object
         playerInitTime = ParseJSON(m._configProperties.player_init_time)
         if playerInitTime > 0
           props.player_startup_time =  m._startTimestamp - playerInitTime
+          if m._viewTimeToFirstFrame <> Invalid AND m._viewTimeToFirstFrame <> 0
+            props.view_aggregate_startup_time = m._viewTimeToFirstFrame + (m._startTimestamp - playerInitTime)
+          end if
         end if
       end if
     end if
@@ -1240,9 +1249,9 @@ function muxAnalytics() as Object
   }
 
   prototype._subsequentWords = {
-   ad: "ad", aggregate: "ag", api: "ap", application: "al", architecture: "ar",
+   ad: "ad", aggregate: "ag", api: "ap", application: "al", audio: "ao", architecture: "ar",
    asset: "as", autoplay: "au", break: "br", code: "cd", category: "cg", config: "cn",
-   count: "co", complete: "cp", content: "ct", current: "cu", downscaling: "dg",
+   count: "co", complete: "cp", content: "ct", current: "cu",country: "cy", downscaling: "dg",
    domain: "dm", cdn: "dn", downscale: "do", duration: "du", device: "dv", encoding: "ec",
    end: "en", engine: "eg", embed: "em", error: "er", events: "ev", expires: "ex", first: "fi",
    family: "fm", format: "ft", frequency: "fq", frame: "fr", fullscreen: "fs", host: "ho",
@@ -1254,9 +1263,9 @@ function muxAnalytics() as Object
    property: "py", rate: "ra", requested: "rd", rebuffer: "re", ratio: "ro", request: "rq",
    requests: "rs", sample: "sa", session: "se", seek: "sk", stream: "sm", source: "so",
    sequence: "sq", series: "sr", start: "st", startup: "su", server: "sv", software: "sw",
-   tag: "ta", tech: "tc", time: "ti", total: "tl", to: "to", title: "tt", type: "ty",
-   upscaling: "ug", upscale: "up", url: "ur", user: "us", variant: "va", viewed: "vd",
-   video: "vi", version: "ve", view: "vw", viewer: "vr", width: "wd", watch: "wa",
+   subtitle: "sb", tag: "ta", tech: "tc", time: "ti", total: "tl", to: "to", title: "tt", 
+   type: "ty",track: "tr", upscaling: "ug", upscale: "up", url: "ur", user: "us", variant: "va", 
+   viewed: "vd", video: "vi", version: "ve", view: "vw", viewer: "vr", width: "wd", watch: "wa",
    waiting: "wt"
   }
 

--- a/test/source_tests/source/tests/Test__GetSessionProperties.brs
+++ b/test/source_tests/source/tests/Test__GetSessionProperties.brs
@@ -9,6 +9,7 @@ Function TestSuite__GetSessionProperties() as Object
   this.addTest("GetSessionProperties Fullscreen", TestCase__MuxAnalytics_fullscreen_always_true)
   this.addTest("GetSessionProperties SDK Name", TestCase__MuxAnalytics_sdk_name)
   this.addTest("GetSessionProperties Player Version", TestCase__MuxAnalytics_player_version)
+  this.addTest("GetSessionProperties Viewer Version", TestCase__MuxAnalytics_viewer_version)
 
   return this
 End Function
@@ -75,6 +76,24 @@ Function TestCase__MuxAnalytics_player_version() as String
   sessionProps = m.SUT._getSessionProperites()
   ' THEN
   return m.assertEqual("7.7.7", sessionProps.player_version)
+End Function
+
+Function TestCase__MuxAnalytics_viewer_version() as String
+  ' GIVEN
+  m.SUT._getAppInfo = function ()
+    fappInfo = FakeAppInfo()
+    fappInfo._GetVersionValueToReturn = "7.7.7"
+    return fappInfo
+  end function 
+  m.SUT._getDeviceInfo = function()
+    deviceInfo = FakeDeviceInfo()
+    deviceInfo._GetVersionValueToReturn = "048.10E04143A"
+    return deviceInfo
+  end function
+  ' WHEN
+  sessionProps = m.SUT._getSessionProperites()
+  ' THEN
+  return m.assertEqual("8.10", sessionProps.viewer_os_version)
 End Function
 
 

--- a/test/source_tests/source/tests/Test__Minification.brs
+++ b/test/source_tests/source/tests/Test__Minification.brs
@@ -21,6 +21,10 @@ Function TestSuite__Minification() as Object
   this.addTest("Minification [3] Terrible Property", TestCase__MuxAnalytics_Minification_minifies_terrible_property_3)
   this.addTest("Minification [4] Terrible Property", TestCase__MuxAnalytics_Minification_minifies_terrible_property_4)
   this.addTest("Minification [5] Terrible Property", TestCase__MuxAnalytics_Minification_minifies_terrible_property_5)
+  this.addTest("Minification [6] video_source_format", TestCase__MuxAnalytics_Minification_minifies_video_source_format)
+  this.addTest("Minification [7] video_source_current_audio_track", TestCase__MuxAnalytics_Minification_minifies_video_source_current_audio_track)
+  this.addTest("Minification [8] video_source_current_subtitle_track", TestCase__MuxAnalytics_Minification_minifies_video_source_current_subtitle_track)
+  this.addTest("Minification [9] player_country_code", TestCase__MuxAnalytics_Minification_minifies_player_country_code)
 
   return this
 End Function
@@ -192,4 +196,44 @@ Function TestCase__MuxAnalytics_Minification_minifies_terrible_property_5() as S
   result = m.SUT._minify(body)
   ' THEN
   return m.assertEqual("omg", result.pp)
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_video_source_format() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {video_source_format: "mp4"}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "vsoft")
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_video_source_current_audio_track() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {video_source_current_audio_track: "http://audiotrack.url"}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "vsocuaotr")
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_video_source_current_subtitle_track() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {video_source_current_subtitle_track: "mp4"}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "vsocusbtr")
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_player_country_code() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {player_country_code: "de"}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "pcycd")
 end function


### PR DESCRIPTION
1. Added new metric `mux_api_version`, hardcoded to '2.0'
2. Added metrics for `viewer_application_name`, `viewer_application_version`, `viewer_device_name` ,`viewer_os_family`, `viewer_os_version`.
3. Renamed the values sent by the sample app to `video_source_current_audio_track` and `video_source_current_subtitle_track`
4. Fixed bug causing `videosourceformat` not to minimise.
5. `aggregate_startup_time` is now `view_time_to_first_frame` plus `player_startup_time`