### PR TITLE
fix "seeked"

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -706,7 +706,7 @@ function muxAnalytics() as Object
         if m._viewSeekDuration <> Invalid
           m._viewSeekDuration = m._viewSeekDuration + (now - seekStartTs)
         end if
-        m._addEventToQueue(m._createEvent("seekend"))
+        m._addEventToQueue(m._createEvent("seeked"))
         m._Flag_isSeeking = false
       end if
     end if


### PR DESCRIPTION
[Bug fix]
When a seek ends, we currently send "seekend" rather than "seeked" (which is what the mux backend expects)