### PR TITLE
pass in player_playhead_time for the first time

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 function init()
-  m.MUX_SDK_VERSION = "1.0.0"
+  m.MUX_SDK_VERSION = "1.0.1"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end function
@@ -1028,8 +1028,10 @@ function muxAnalytics() as Object
         end if
       end if
     end if
-    if m.video.position <> Invalid
-      props.player_playhead_time = Int(m.video.position * 1000)
+    if m.video <> Invalid
+      if m.video.position <> Invalid
+        props.player_playhead_time = Int(m.video.position * 1000)
+      end if
     end if
 
     return props

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1028,6 +1028,9 @@ function muxAnalytics() as Object
         end if
       end if
     end if
+    if m.video.position <> Invalid
+      props.player_playhead_time = Int(m.video.position * 1000)
+    end if
 
     return props
   end function


### PR DESCRIPTION
As it turns out, we never passed the playhead position in our Roku SDK before. This does not affect any metrics, but for completeness we should.

Things to check:
 - [x] `player_playhead_time` is correct for VOD content
 - [x] `player_playhead_time` is correct for Live content

The reason to check both is that the docs mention that you might get an epoch timestamp, which I assume is in seconds, and _should_ work, but it might be worth while to take the first value we send and set that to 0 (or some number that allows for some backwards travel), so that we can make the values seem reasonable, but we probably don't need to do this at all.