### PR TITLE
Remove default video id

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 function init()
-  m.MUX_SDK_VERSION = "1.1.1"
+  m.MUX_SDK_VERSION = "1.2.0"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end function

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -869,8 +869,6 @@ function muxAnalytics() as Object
       end if
       if content.video_id <> Invalid AND (type(content.video_id) = "String" OR type(content.video_id) = "roString") AND content.video_id <> ""
         props.video_id = content.video_id
-      else
-        props.video_id = m._generateVideoId(content.URL)
       end if
       if content.ContentType <> Invalid
         if type(content.ContentType) = "roInt"
@@ -1147,15 +1145,6 @@ function muxAnalytics() as Object
       return cookie.Read("UserRegistrationToken")
     end if
     return Invalid
-  end function
-
-  prototype._generateVideoId= function(src as String) as String
-    hostAndPath = m._getHostnameAndPath(src)
-    byteArray = _createByteArray()
-    byteArray.FromAsciiString(hostAndPath)
-    bigString = byteArray.ToBase64String()
-    smallString = bigString.split("=")[0]
-    return smallString
   end function
 
   prototype._minify = function(src as Object) as Object

--- a/test/source_tests/source/tests/Test__GenerateVideoID.brs
+++ b/test/source_tests/source/tests/Test__GenerateVideoID.brs
@@ -13,8 +13,6 @@ Function TestSuite__GenerateVideoID() as Object
   this.addTest("Get HostnameAndPath [6]", TestCase__MuxAnalytics_GetHostnameAndPath_6)
   this.addTest("Get HostnameAndPath [7]", TestCase__MuxAnalytics_GetHostnameAndPath_7)
   this.addTest("Get HostnameAndPath [7]", TestCase__MuxAnalytics_GetHostnameAndPath_8)
-  this.addTest("Get Generate Video ID [1]", TestCase__MuxAnalytics_GenerateVideoID_1)
-  this.addTest("Get Generate Video ID [2]", TestCase__MuxAnalytics_GenerateVideoID_2)
 
   return this
 End Function
@@ -92,20 +90,3 @@ Function TestCase__MuxAnalytics_GetHostnameAndPath_8() as String
   ' END
   return m.assertEqual(result, "")
 End Function
-
-Function TestCase__MuxAnalytics_GenerateVideoID_1() as String
-  ' GIVEN
-  ' WHEN
-  result = m.SUT._generateVideoId("http://akami.com/this/should/be/included/#test=https://somethingelse")
-  ' END
-  return m.assertEqual(result, "YWthbWkuY29tL3RoaXMvc2hvdWxkL2JlL2luY2x1ZGVkLw")
-End Function
-
-Function TestCase__MuxAnalytics_GenerateVideoID_2() as String
-  ' GIVEN
-  ' WHEN
-  result = m.SUT._generateVideoId("")
-  ' END
-  return m.assertEqual(result, "")
-End Function
-


### PR DESCRIPTION
Remove the creation of a default video id value when one isn't specified. This will match native behavior and we could handle a default on the server, if necessary.