### PR TITLE
Fix model number being null in some cases

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -819,7 +819,12 @@ function muxAnalytics() as Object
     props.viewer_device_name = deviceInfo.GetModelDisplayName()
     props.viewer_device_category = "tv"
     props.viewer_device_manufacturer = deviceInfo.GetModelDetails()["VendorName"]
-    props.viewer_device_model = deviceInfo.GetModel()
+    ' If GetModel() is invalid, try the specific model number
+    seriesModel = deviceInfo.GetModel()
+    if seriesModel = invalid then
+      seriesModel = deviceInfo.GetModelDetails()["ModelNumber"]
+    end if
+    props.viewer_device_model = seriesModel
     props.viewer_os_family = "Roku OS"
     props.viewer_os_version = firmwareVersion
     props.viewer_connection_type = _getConnectionType(deviceInfo)

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 function init()
-  m.MUX_SDK_VERSION = "1.2.1"
+  m.MUX_SDK_VERSION = "1.3.1"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end function

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -819,12 +819,7 @@ function muxAnalytics() as Object
     props.viewer_device_name = deviceInfo.GetModelDisplayName()
     props.viewer_device_category = "tv"
     props.viewer_device_manufacturer = deviceInfo.GetModelDetails()["VendorName"]
-    ' If GetModel() is invalid, try the specific model number
-    seriesModel = deviceInfo.GetModel()
-    if seriesModel = invalid then
-      seriesModel = deviceInfo.GetModelDetails()["ModelNumber"]
-    end if
-    props.viewer_device_model = seriesModel
+    props.viewer_device_model = deviceInfo.GetModel()
     props.viewer_os_family = "Roku OS"
     props.viewer_os_version = firmwareVersion
     props.viewer_connection_type = _getConnectionType(deviceInfo)


### PR DESCRIPTION
According to the docs, If the "main" model number isn't available we can fall-back to a more specific model. For example  `1200X` vs `1234-1` or something.

In practice, my Roku at home reported the same, specific model number for both values