### PR TITLE
Update `getHostname` to handle domain names with hyphens

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 function init()
-  m.MUX_SDK_VERSION = "1.3.1"
+  m.MUX_SDK_VERSION = "1.3.2"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end function

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1105,7 +1105,7 @@ function muxAnalytics() as Object
 
   prototype._getHostname = function(url as String) as String
     host = ""
-    hostRegex = CreateObject("roRegex", "([a-z]{1,})(\.)([a-z.]{1,})", "i")
+    hostRegex = CreateObject("roRegex", "([a-z0-9\-]{1,})(\.)([a-z0-9\-\.]{1,})", "i")
     matchResults = hostRegex.Match(url)
     if matchResults.count() > 0
       host = matchResults[0]

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1095,7 +1095,7 @@ function muxAnalytics() as Object
     if strippedUrl.count() > 0
       url = strippedUrl[0]
     end if
-    domainRegex = CreateObject("roRegex", "([a-z0-9\-]+)\.([a-z]+|[a-z]{2}\.[a-z]+)$", "i")
+    domainRegex = CreateObject("roRegex", "([a-z0-9\-]+)\.([a-z0-9\-]+|[a-z0-9\-]{2}\.[a-z0-9\-]+)$", "i")
     matchResults = domainRegex.Match(url)
     if matchResults.count() > 0
       domain = matchResults[0]
@@ -1105,7 +1105,7 @@ function muxAnalytics() as Object
 
   prototype._getHostname = function(url as String) as String
     host = ""
-    hostRegex = CreateObject("roRegex", "([a-z0-9\-]{1,})(\.)([a-z0-9\-\.]{1,})", "i")
+    hostRegex = CreateObject("roRegex", "([a-z0-9\-]+)(\.)([a-z0-9\-\.]+)", "i")
     matchResults = hostRegex.Match(url)
     if matchResults.count() > 0
       host = matchResults[0]

--- a/test/component_tests/components/tests/Test__MuxTask_Url_Utils.brs
+++ b/test/component_tests/components/tests/Test__MuxTask_Url_Utils.brs
@@ -10,7 +10,9 @@ Function TestSuite__MuxTask_Url_Utils() as Object
     ' this.addTest("TestCase__find_domain_three", TestCase__find_domain_three)
     ' this.addTest("TestCase__find_hostname_four", TestCase__find_hostname_four)
     ' this.addTest("TestCase__find_domain_four", TestCase__find_domain_four)
-    
+    this.addTest("TestCase__find_hostname_with_hyphen", TestCase__find_hostname_with_hyphen)
+    this.addTest("TestCase__find_domain_with_hyphen", TestCase__find_domain_with_hyphen)
+
     return this
 End Function
 
@@ -56,3 +58,12 @@ function TestCase__find_domain_four() as Object
   return m.assertEqual(result, "company.com")
 end function
 
+function TestCase__find_hostname_with_hyphen() as Object
+  result = _getHostname("http://video-test.company-test.com/test.mp4?correlator=123456")
+  return m.assertEqual(result, "video-test.company-test.com")
+end function
+
+function TestCase__find_domain_with_hyphen() as Object
+  result = _getDomain("http://video-test.company-test.com/test.mp4?correlator=123456")
+  return m.assertEqual(result, "company-test.com")
+end function


### PR DESCRIPTION
* Update the regex in getHostname to properly handle domains that contain a hyphen
* Add tests for getDomain and getHostname for domains with hyphens.