### PR TITLE
v2.0.0

### DIFF
--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -8,6 +8,7 @@
     <field id="exit" type="Boolean" alwaysNotify="true"/>
     <field id="useRenderStitchedStream" type="String" alwaysNotify="true" value="false"/>
     <field id="useSSAI" type="String" alwaysNotify="true" value="false"/>
+    <field id="automaticErrorTracking" type="String" alwaysNotify="true" value="true"/>
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -6,9 +6,9 @@
     <field id="error" type="assocarray" alwaysNotify="true"/>
     <field id="view" type="String" alwaysNotify="true"/>
     <field id="exit" type="Boolean" alwaysNotify="true"/>
-    <field id="useRenderStitchedStream" type="String" alwaysNotify="true" value="false"/>
-    <field id="useSSAI" type="String" alwaysNotify="true" value="false"/>
-    <field id="automaticErrorTracking" type="String" alwaysNotify="true" value="true"/>
+    <field id="useRenderStitchedStream" type="Boolean" alwaysNotify="true" value="false"/>
+    <field id="useSSAI" type="Boolean" alwaysNotify="true" value="false"/>
+    <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>

--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -9,6 +9,7 @@
     <field id="useRenderStitchedStream" type="String" alwaysNotify="true" value="false"/>
     <field id="useSSAI" type="String" alwaysNotify="true" value="false"/>
     <field id="automaticErrorTracking" type="String" alwaysNotify="true" value="true"/>
+    <field id="randomMuxViewerId" type="Boolean" value="false"/>
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -9,6 +9,7 @@
     <field id="exitType" type="String" alwaysNotify="true" value="hard"/>
     <field id="useRenderStitchedStream" type="String" alwaysNotify="true" value="false"/>
     <field id="useSSAI" type="String" alwaysNotify="true" value="false"/>
+    <field id="automaticErrorTracking" type="String" alwaysNotify="true" value="true"/>
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -7,9 +7,9 @@
     <field id="view" type="String" alwaysNotify="true"/>
     <field id="exit" type="Boolean" alwaysNotify="true"/>
     <field id="exitType" type="String" alwaysNotify="true" value="hard"/>
-    <field id="useRenderStitchedStream" type="String" alwaysNotify="true" value="false"/>
-    <field id="useSSAI" type="String" alwaysNotify="true" value="false"/>
-    <field id="automaticErrorTracking" type="String" alwaysNotify="true" value="true"/>
+    <field id="useRenderStitchedStream" type="Boolean" alwaysNotify="true" value="false"/>
+    <field id="useSSAI" type="Boolean" alwaysNotify="true" value="false"/>
+    <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -10,6 +10,7 @@
     <field id="useRenderStitchedStream" type="String" alwaysNotify="true" value="false"/>
     <field id="useSSAI" type="String" alwaysNotify="true" value="false"/>
     <field id="automaticErrorTracking" type="String" alwaysNotify="true" value="true"/>
+    <field id="randomMuxViewerId" type="Boolean" value="false"/>
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/PlayerTask.brs
+++ b/sampleapp_source/components_reset/components/PlayerTask.brs
@@ -165,6 +165,7 @@ sub PlayContentOnlyNoAds(contentInfo as Object)
           video.control = "stop"
           mux = GetGlobalAA().global.findNode("mux")
           mux.setField("view", "end")
+          mux.setField("exit", true)
         end if
       end if
     end if

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "1.8.0"
+  m.MUX_SDK_VERSION = "2.0.0"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end sub

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "1.9.0-dev.1"
+  m.MUX_SDK_VERSION = "1.8.0"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end sub
@@ -542,8 +542,13 @@ function muxAnalytics() as Object
       m._Flag_atLeastOnePlayEventForContent = true
     else if videoState = "stopped"
     else if videoState = "finished"
-      m._addEventToQueue(m._createEvent("ended"))
-      m._endView()
+      ' Only send ended event if it played to completion
+      completedStreamInfo = m.video.completedStreamInfo
+      if completedStreamInfo <> invalid
+        if completedStreamInfo.isFullResult
+          m._addEventToQueue(m._createEvent("ended"))
+        end if
+      end if
     else if videoState = "error"
       ' Bail out if we aren't supposed to track automatic errors
       if not m._Flag_automaticErrorTracking then return

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -774,6 +774,8 @@ function muxAnalytics() as Object
     errorCode = "0"
     errorMessage = "Unknown"
     errorContext = "No additional information"
+    errorSeverity = "fatal"
+    isBusinessException = false
     if error <> Invalid
       if error.errorCode <> Invalid
         errorCode = error.errorCode
@@ -786,9 +788,17 @@ function muxAnalytics() as Object
       end if
       if error.errorContext <> Invalid
         errorContext = error.errorContext
-      end if 
+      end if
+      if error.errorSeverity <> Invalid
+        if error.errorSeverity = "warning"
+          errorSeverity = "warning"
+        end if
+      end if
+      if error.isBusinessException <> Invalid
+        isBusinessException = (error.isBusinessException = "true")
+      end if
     end if
-    m._addEventToQueue(m._createEvent("error", {player_error_code: errorCode, player_error_message:errorMessage, player_error_context:errorContext}))
+    m._addEventToQueue(m._createEvent("error", {player_error_code: errorCode, player_error_message:errorMessage, player_error_context:errorContext, player_error_severity:errorSeverity, player_error_business_exception:isBusinessException}))
   end sub
 
   prototype.rafEventHandler = sub(rafEvent)

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -96,10 +96,10 @@ function runBeaconLoop()
   end if
   m.top.ObserveField("useSSAI", m.messagePort)
 
-  if m.top.automaticErrorTracking <> Invalid
-    m.mxa.automaticErrorTrackingHandler(m.top.automaticErrorTracking)
+  if m.top.disableAutomaticErrorTracking <> Invalid
+    m.mxa.disableAutomaticErrorTrackingHandler(m.top.disableAutomaticErrorTracking)
   end if
-  m.top.ObserveField("automaticErrorTracking", m.messagePort)
+  m.top.ObserveField("disableAutomaticErrorTracking", m.messagePort)
 
   if m.top.error <> Invalid
     m.mxa.videoErrorHandler(m.top.error)
@@ -210,7 +210,7 @@ function runBeaconLoop()
   m.top.UnobserveField("view")
   m.top.UnobserveField("useRenderStitchedStream")
   m.top.UnobserveField("useSSAI")
-  m.top.UnobserveField("automaticErrorTracking")
+  m.top.UnobserveField("disableAutomaticErrorTracking")
 
   if m.top.exitType = "soft"
     while NOT m.mxa.isQueueEmpty()
@@ -761,21 +761,21 @@ function muxAnalytics() as Object
     end if
   end sub
 
-  prototype.useRenderStitchedStreamHandler = sub(useRenderStitchedStream as String)
+  prototype.useRenderStitchedStreamHandler = sub(useRenderStitchedStream as Boolean)
     if useRenderStitchedStream <> Invalid
-      m._Flag_useRenderStitchedStream = (useRenderStitchedStream = "true")
+      m._Flag_useRenderStitchedStream = useRenderStitchedStream
     end if
   end sub
 
-  prototype.useSSAIHandler = sub(useSSAI as String)
+  prototype.useSSAIHandler = sub(useSSAI as Boolean)
     if useSSAI <> Invalid
-      m._Flag_useSSAI = (useSSAI = "true")
+      m._Flag_useSSAI = useSSAI
     end if
   end sub
 
-  prototype.automaticErrorTrackingHandler = sub(automaticErrorTracking as String)
-    if automaticErrorTracking <> Invalid
-      m._Flag_automaticErrorTracking = (automaticErrorTracking = "true")
+  prototype.disableAutomaticErrorTrackingHandler = sub(disableAutomaticErrorTracking as Boolean)
+    if disableAutomaticErrorTracking <> Invalid
+      m._Flag_automaticErrorTracking = (not disableAutomaticErrorTracking)
     end if
   end sub
 
@@ -804,7 +804,7 @@ function muxAnalytics() as Object
         end if
       end if
       if error.isBusinessException <> Invalid
-        isBusinessException = (error.isBusinessException = "true")
+        isBusinessException = (error.isBusinessException = "true" or error.isBusinessException)
       end if
     end if
     m._addEventToQueue(m._createEvent("error", {player_error_code: errorCode, player_error_message:errorMessage, player_error_context:errorContext, player_error_severity:errorSeverity, player_error_business_exception:isBusinessException}))


### PR DESCRIPTION
 - add support for `disableAutomaticErrorTracking`
 - add support for `useRandomMuxViewerId`
 - fix issue where `ended` event was sent when it should not have been
 - support severity and business exception in manual error handler
 - BREAKING: `disableAutomaticErrorTracking`, `useRenderStitchedStream`, and `useSSAI` have had their types changed to `Boolean`, so you will need to make sure to update your `MuxTask.xml` files to the right types, and anywhere you might set those values dynamically