### PR TITLE
Viewer Connection Type recheck and updated values 

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -278,6 +278,9 @@ end function
 
 function _getConnectionType(deviceInfo as Object)
   connectionType = deviceInfo.GetConnectionType()
+  if connectionType = ""
+    return Invalid
+  end if
   if connectionType = "WiFiConnection"
     return "wifi"
   end if
@@ -285,7 +288,7 @@ function _getConnectionType(deviceInfo as Object)
     return "ethernet"
   end if
 
-  return "none"
+  return "other"
 end function
 
 function muxAnalytics() as Object
@@ -446,7 +449,10 @@ function muxAnalytics() as Object
 
   prototype.updateSessionPropertiesConnectionType = sub()
     deviceInfo = m._getDeviceInfo()
-    m._sessionProperties.viewer_connection_type = _getConnectionType(deviceInfo)
+    connectionType = _getConnectionType(deviceInfo)
+    if connectionType <> Invalid
+      m._sessionProperties.viewer_connection_type = connectionType
+    end if
   end sub
 
   prototype.heartbeatIntervalHandler = sub(heartbeatIntervalEvent)
@@ -1346,7 +1352,10 @@ function muxAnalytics() as Object
     props.viewer_device_model = seriesModel
     props.viewer_os_family = "Roku OS"
     props.viewer_os_version = firmwareVersion
-    props.viewer_connection_type = _getConnectionType(deviceInfo)
+    connectionType = _getConnectionType(deviceInfo)
+    if connectionType <> Invalid
+      props.viewer_connection_type = connectionType
+    end if
     props.mux_api_version = m.MUX_API_VERSION
     props.player_mux_plugin_name = m.MUX_SDK_NAME
     props.player_mux_plugin_version = m.MUX_SDK_VERSION

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -405,8 +405,8 @@ function muxAnalytics() as Object
     m._viewRequestCount = Invalid
 
     ' Calculate player width and height
-    deviceInfo = m._getDeviceInfo()
-    videoMode = deviceInfo.GetVideoMode()
+    m.deviceInfo = m._getDeviceInfo()
+    videoMode = m.deviceInfo.GetVideoMode()
     m._lastPlayerWidth = Val(m._getVideoPlaybackMetric(videoMode, "width"))
     m._lastPlayerHeight = Val(m._getVideoPlaybackMetric(videoMode, "height"))
 
@@ -448,8 +448,7 @@ function muxAnalytics() as Object
   end sub
 
   prototype.updateSessionPropertiesConnectionType = sub()
-    deviceInfo = m._getDeviceInfo()
-    connectionType = _getConnectionType(deviceInfo)
+    connectionType = _getConnectionType(m.deviceInfo)
     if connectionType <> Invalid
       m._sessionProperties.viewer_connection_type = connectionType
     end if

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -440,7 +440,13 @@ function muxAnalytics() as Object
 
   prototype.beaconIntervalHandler = sub(beaconIntervalEvent)
     data = beaconIntervalEvent.getData()
+    m.updateSessionPropertiesConnectionType()
     m.LIGHT_THE_BEACONS()
+  end sub
+
+  prototype.updateSessionPropertiesConnectionType = sub()
+    deviceInfo = m._getDeviceInfo()
+    m._sessionProperties.viewer_connection_type = _getConnectionType(deviceInfo)
   end sub
 
   prototype.heartbeatIntervalHandler = sub(heartbeatIntervalEvent)


### PR DESCRIPTION
This PR contains changes to the way the device connection type is obtained and when it is updated.

- Added an `updateSessionPropertiesConnectionType()` on the `beaconIntervalHandler`, with the purpose of obtaining the device connection type and updating it, in order to have an updated value every 10 seconds
- In `_getConnectionType()` now we return `Invalid` if the result of `GetConnectionType` is `""` and if the result of `GetConnectionType` does not match `"WiFiConnection"` or `"WiredConnection"`, it returns `"other"`. Also added checking to not set the `viewer_connection_type` if the return value is `Invalid`