### PR TITLE
CDN Events

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -386,7 +386,7 @@ function muxAnalytics() as Object
     m._viewPrerollPlayedCount = Invalid
     m._videoSourceFormat = Invalid
     m._videoSourceDuration = Invalid
-    m._videoSourceURL = Invalid
+    m._videoCurrentCdn = Invalid
     m._viewPrerollPlayedCount = Invalid
 
     m._lastSourceWidth = Invalid
@@ -603,11 +603,14 @@ function muxAnalytics() as Object
   end sub
 
   prototype.cndSwitchHandler = sub(cdnData as Object)
-    previousCdn = m._videoSourceURL
+    currentCdn = ""
+    if m._videoCurrentCdn <> Invalid
+      currentCdn = m._videoCurrentCdn
+    end if
     newCdn = m._getUrlWithoutMetadata(cdnData.URLFilter)
 
-    m._addEventToQueue(m._createEvent("cdnchange", { video_cdn: newCdn, video_previous_cdn: previousCdn }))
-    previousCdn = newCdn
+    m._addEventToQueue(m._createEvent("cdnchange", { video_cdn: newCdn, video_previous_cdn: currentCdn }))
+    m._videoCurrentCdn = newCdn
   end sub
 
   prototype._triggerPlayEvent = sub()
@@ -1253,7 +1256,7 @@ function muxAnalytics() as Object
       m._viewPrerollPlayedCount = Invalid
       m._videoSourceFormat = Invalid
       m._videoSourceDuration = Invalid
-      m._videoSourceURL = Invalid
+      m._videoCurrentCdn = Invalid
       m.drmType = Invalid
       m.droppedFrames = Invalid
 
@@ -1432,7 +1435,6 @@ function muxAnalytics() as Object
         props.video_source_hostname = m._getHostname(content.URL)
         props.video_source_domain = m._getDomain(content.URL)
         m._videoSourceFormat = m._getVideoFormat(content.URL)
-        m._videoSourceURL = content.URL
       end if
 
       if content.StreamFormat <> Invalid AND (type(content.StreamFormat) = "String" OR type(content.StreamFormat) = "roString") AND content.StreamFormat <> "(null)"

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -70,6 +70,7 @@ function runBeaconLoop()
     m.top.video.ObserveField("contentIndex", m.messagePort)
     m.top.video.ObserveField("downloadedSegment", m.messagePort)
     m.top.video.ObserveField("streamingSegment", m.messagePort)
+    m.top.video.ObserveField("cdnSwitch", m.messagePort)
     if m.top.video.enableDecoderStats <> Invalid
       m.top.video.enableDecoderStats = true
       m.top.video.ObserveField("decoderStats", m.messagePort)
@@ -144,6 +145,7 @@ function runBeaconLoop()
             m.top.video.ObserveField("contentIndex", m.messagePort)
             m.top.video.ObserveField("downloadedSegment", m.messagePort)
             m.top.video.ObserveField("streamingSegment", m.messagePort)
+            m.top.video.ObserveField("cdnSwitch", m.messagePort)
             if m.top.video.enableDecoderStats <> Invalid
               m.top.video.enableDecoderStats = true
               m.top.video.ObserveField("decoderStats", m.messagePort)
@@ -189,6 +191,9 @@ function runBeaconLoop()
           else if node = "heartbeatTimer"
             m.mxa.heartbeatIntervalHandler(msg)
           end if
+        else if field = "cdnSwitch"
+          print "HERE HERE"
+          m.mxa.cndSwitchHandler(msg.getData())
         end if
       end if
     end if
@@ -595,6 +600,10 @@ function muxAnalytics() as Object
     else if view = "start"
       m._startView(true)
     end if
+  end sub
+
+  prototype.cndSwitchHandler = sub(cdnData as Object)
+    print cdnData
   end sub
 
   prototype._triggerPlayEvent = sub()

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -192,7 +192,6 @@ function runBeaconLoop()
             m.mxa.heartbeatIntervalHandler(msg)
           end if
         else if field = "cdnSwitch"
-          print "HERE HERE"
           m.mxa.cndSwitchHandler(msg.getData())
         end if
       end if


### PR DESCRIPTION
This PR implements CDN switching event listening and creation.
We now listen for the cdnSwitch event and we call the cndSwitchHandler, which sends the cdnchange event containing:

- video_cdn: the current CDN
- video_previous_cdn: the CDN we are switching from, if we know it, else, we send an empty string