### PR TITLE
Error Code Inconsistencies

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -788,21 +788,25 @@ function muxAnalytics() as Object
     if error <> Invalid
       if error.errorCode <> Invalid
         errorCode = error.errorCode
-      else if error.player_error_code <> Invalid
+      end if
+      if error.player_error_code <> Invalid
         errorCode = error.player_error_code
       end if
 
       if error.errorMsg <> Invalid
         errorMessage = error.errorMsg
-      else if error.errorMessage <> Invalid
+      end if
+      if error.errorMessage <> Invalid
         errorMessage = error.errorMessage
-      else if error.player_error_messsage <> Invalid
+      end if
+      if error.player_error_messsage <> Invalid
         errorMessage = error.player_error_message
       end if
 
       if error.errorContext <> Invalid
         errorContext = error.errorContext
-      else if error.player_error_context <> Invalid
+      end if
+      if error.player_error_context <> Invalid
         errorContext = error.player_error_context
       end if
 
@@ -810,7 +814,8 @@ function muxAnalytics() as Object
         if error.errorSeverity = "warning"
           errorSeverity = "warning"
         end if
-      else if error.player_error_severity <> Invalid
+      end if
+      if error.player_error_severity <> Invalid
         if error.player_error_severity = "warning"
           errorSeverity = "warning"
         end if
@@ -818,7 +823,8 @@ function muxAnalytics() as Object
 
       if error.isBusinessException <> Invalid
         isBusinessException = error.isBusinessException
-      else if error.player_error_business_exception <> Invalid
+      end if
+      if error.player_error_business_exception <> Invalid
         isBusinessException = error.player_error_business_exception
       end if
     end if

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -788,23 +788,38 @@ function muxAnalytics() as Object
     if error <> Invalid
       if error.errorCode <> Invalid
         errorCode = error.errorCode
+      else if error.player_error_code <> Invalid
+        errorCode = error.player_error_code
       end if
+
       if error.errorMsg <> Invalid
         errorMessage = error.errorMsg
-      end if
-      if error.errorMessage <> Invalid
+      else if error.errorMessage <> Invalid
         errorMessage = error.errorMessage
+      else if error.player_error_messsage <> Invalid
+        errorMessage = error.player_error_message
       end if
+
       if error.errorContext <> Invalid
         errorContext = error.errorContext
+      else if error.player_error_context <> Invalid
+        errorContext = error.player_error_context
       end if
+
       if error.errorSeverity <> Invalid
         if error.errorSeverity = "warning"
           errorSeverity = "warning"
         end if
+      else if error.player_error_severity <> Invalid
+        if error.player_error_severity = "warning"
+          errorSeverity = "warning"
+        end if
       end if
+
       if error.isBusinessException <> Invalid
-        isBusinessException = (error.isBusinessException = "true" or error.isBusinessException)
+        isBusinessException = error.isBusinessException
+      else if error.player_error_business_exception <> Invalid
+        isBusinessException = error.player_error_business_exception
       end if
     end if
     m._addEventToQueue(m._createEvent("error", {player_error_code: errorCode, player_error_message:errorMessage, player_error_context:errorContext, player_error_severity:errorSeverity, player_error_business_exception:isBusinessException}))


### PR DESCRIPTION
This PR implements a fix for the inconsistencies between the documentation and the code regarding how should error data should be sent.

We now support both of these

```
mux.setField("error", {
  player_error_code: errorCode,
  player_error_message: errorMessage,
  player_error_context: errorContext,
  player_error_severity: errorSeverity,
  player_error_business_exception: isBusinessException
})
```

```
mux.setField("error", {
  errorCode: errorCode,
  errorMsg: errorMessage,
  errorContext: errorContext
  errorSeverity: errorSeverity,
  isBusinessException: isBusinessException
})
```

Also changed how the `isBusinessException` is set, now we just set it to the value sent, no checking against a string, which caused the mismatch error. 