### PR TITLE
v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3",
+  "version": "2.1.0",
   "main": "./src/mux-analytics.brs",
   "dependencies": {
     "@rokucommunity/bslint": "^0.8.9",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "./src/mux-analytics.brs",
   "dependencies": {
     "@rokucommunity/bslint": "^0.8.9",

--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -10,6 +10,7 @@
     <field id="useSSAI" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
+    <field id="cdn" type="String" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -11,6 +11,7 @@
     <field id="useSSAI" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
+    <field id="cdn" type="String" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -106,6 +106,11 @@ function runBeaconLoop()
   end if
   m.top.ObserveField("error", m.messagePort)
 
+  if m.top.cdn <> invalid
+    m.mxa.cdnChangeHandler(m.top.cdn)
+  end if
+  m.top.ObserveField("cdn", m.messagePort)
+
   m.pollTimer.ObserveField("fire", m.messagePort)
   m.beaconTimer.ObserveField("fire", m.messagePort)
   m.heartbeatTimer.ObserveField("fire", m.messagePort)
@@ -189,6 +194,8 @@ function runBeaconLoop()
           else if node = "heartbeatTimer"
             m.mxa.heartbeatIntervalHandler(msg)
           end if
+        else if field = "cdn"
+          m.mxa.cdnChangeHandler(msg.getData())
         end if
       end if
     end if
@@ -385,6 +392,7 @@ function muxAnalytics() as Object
     m._viewPrerollPlayedCount = Invalid
     m._videoSourceFormat = Invalid
     m._videoSourceDuration = Invalid
+    m._videoCurrentCdn = Invalid
     m._viewPrerollPlayedCount = Invalid
 
     m._lastSourceWidth = Invalid
@@ -605,6 +613,18 @@ function muxAnalytics() as Object
       m._endView(true)
     else if view = "start"
       m._startView(true)
+    end if
+  end sub
+
+  prototype.cdnChangeHandler = sub(cdn as String)
+    previousCdn = ""
+    if m._videoCurrentCdn <> Invalid
+      previousCdn = m._videoCurrentCdn
+    end if
+
+    if cdn <> Invalid and cdn <> previousCdn
+      m._addEventToQueue(m._createEvent("cdnchange", { video_cdn: cdn, video_previous_cdn: previousCdn }))
+      m._videoCurrentCdn = cdn
     end if
   end sub
 
@@ -1272,6 +1292,7 @@ function muxAnalytics() as Object
       m._viewPrerollPlayedCount = Invalid
       m._videoSourceFormat = Invalid
       m._videoSourceDuration = Invalid
+      m._videoCurrentCdn = Invalid
       m.drmType = Invalid
       m.droppedFrames = Invalid
 
@@ -2061,6 +2082,7 @@ function muxAnalytics() as Object
     "producer": "pd",
     "percentage": "pe",
     "played": "pf",
+    "previous": "pv",
     "program": "pg",
     "playhead": "ph",
     "plugin": "pi",

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "2.0.3"
+  m.MUX_SDK_VERSION = "2.1.0"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end sub

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "2.0.2"
+  m.MUX_SDK_VERSION = "2.0.3"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
 end sub

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -800,22 +800,43 @@ function muxAnalytics() as Object
       if error.errorCode <> Invalid
         errorCode = error.errorCode
       end if
+      if error.player_error_code <> Invalid
+        errorCode = error.player_error_code
+      end if
+
       if error.errorMsg <> Invalid
         errorMessage = error.errorMsg
       end if
       if error.errorMessage <> Invalid
         errorMessage = error.errorMessage
       end if
+      if error.player_error_messsage <> Invalid
+        errorMessage = error.player_error_message
+      end if
+
       if error.errorContext <> Invalid
         errorContext = error.errorContext
       end if
+      if error.player_error_context <> Invalid
+        errorContext = error.player_error_context
+      end if
+
       if error.errorSeverity <> Invalid
         if error.errorSeverity = "warning"
           errorSeverity = "warning"
         end if
       end if
+      if error.player_error_severity <> Invalid
+        if error.player_error_severity = "warning"
+          errorSeverity = "warning"
+        end if
+      end if
+
       if error.isBusinessException <> Invalid
-        isBusinessException = (error.isBusinessException = "true" or error.isBusinessException)
+        isBusinessException = error.isBusinessException
+      end if
+      if error.player_error_business_exception <> Invalid
+        isBusinessException = error.player_error_business_exception
       end if
     end if
     m._addEventToQueue(m._createEvent("error", {player_error_code: errorCode, player_error_message:errorMessage, player_error_context:errorContext, player_error_severity:errorSeverity, player_error_business_exception:isBusinessException}))


### PR DESCRIPTION
- fix error code inconsistencies on `error` event handling
- `viewer_connection_type` is set to invalid if unable to be determined, set to "other" if not wired or wireless
- `viewer_connection_type` is now updated every 10 seconds
- created new "cdn" user event, which triggers a "cdnchange" analytics event, containg the current and previous CDN