### PR TITLE
Rebuffer Controls

### DIFF
--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -11,7 +11,7 @@
     <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
     <field id="cdn" type="String" alwaysNotify="true" />
-    <field id="disableAutomaticRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
+    <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
     <field id="rebufferstart" type="void" alwaysNotify="true" />
     <field id="rebufferend" type="void" alwaysNotify="true" />
   </interface>

--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -11,9 +11,9 @@
     <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
     <field id="cdn" type="String" alwaysNotify="true" />
-    <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
-    <field id="rebufferstart" type="void" alwaysNotify="true" />
-    <field id="rebufferend" type="void" alwaysNotify="true" />
+    <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="true" />
+    <field id="rebufferstart" type="Boolean" alwaysNotify="true" />
+    <field id="rebufferend" type="Boolean" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -11,6 +11,9 @@
     <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
     <field id="cdn" type="String" alwaysNotify="true" />
+    <field id="disableAutomaticRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
+    <field id="rebufferstart" alwaysNotify="true" />
+    <field id="rebufferend" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -12,8 +12,8 @@
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
     <field id="cdn" type="String" alwaysNotify="true" />
     <field id="disableAutomaticRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
-    <field id="rebufferstart" alwaysNotify="true" />
-    <field id="rebufferend" alwaysNotify="true" />
+    <field id="rebufferstart" type="void" alwaysNotify="true" />
+    <field id="rebufferend" type="void" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -12,6 +12,9 @@
     <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
     <field id="cdn" type="String" alwaysNotify="true" />
+    <field id="disableAutomaticRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
+    <field id="rebufferstart" type="void" alwaysNotify="true" />
+    <field id="rebufferend" type="void" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -12,7 +12,7 @@
     <field id="disableAutomaticErrorTracking" type="Boolean" alwaysNotify="true" value="false"/>
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
     <field id="cdn" type="String" alwaysNotify="true" />
-    <field id="disableAutomaticRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
+    <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
     <field id="rebufferstart" type="void" alwaysNotify="true" />
     <field id="rebufferend" type="void" alwaysNotify="true" />
   </interface>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -13,8 +13,8 @@
     <field id="randomMuxViewerId" type="Boolean" value="false"/>
     <field id="cdn" type="String" alwaysNotify="true" />
     <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
-    <field id="rebufferstart" type="void" alwaysNotify="true" />
-    <field id="rebufferend" type="void" alwaysNotify="true" />
+    <field id="rebufferstart" type="Boolean" alwaysNotify="true" />
+    <field id="rebufferend" type="Boolean" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -116,15 +116,8 @@ function runBeaconLoop()
   end if
   m.top.ObserveField("disablePlayheadRebufferTracking", m.messagePort)
 
-  if m.top.rebufferstart <> Invalid
-    m.mxa.rebufferStartHandler(m.top.rebufferstart)
-  end if
   m.top.ObserveField("rebufferstart", m.messagePort)
-
-  if m.top.rebufferend <> Invalid
-    m.mxa.rebufferEndHandler(m.top.rebufferend, m.messagePort)
-  end if
-  m.top.ObserveField("rebufferend")
+  m.top.ObserveField("rebufferend", m.messagePort)
 
   m.pollTimer.ObserveField("fire", m.messagePort)
   m.beaconTimer.ObserveField("fire", m.messagePort)
@@ -211,6 +204,12 @@ function runBeaconLoop()
           end if
         else if field = "cdn"
           m.mxa.cdnChangeHandler(msg.getData())
+        else if field = "disablePlayheadRebufferTracking"
+          m.mxa.disablePlayheadRebufferTrackingHandler(msg.getData())
+        else if field = "rebufferstart"
+          m.mxa.rebufferStartHandler()
+        else if field = "rebufferend"
+          m.mxa.rebufferEndHandler()
         end if
       end if
     end if

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -106,15 +106,15 @@ function runBeaconLoop()
   end if
   m.top.ObserveField("error", m.messagePort)
 
-  if m.top.cdn <> invalid
+  if m.top.cdn <> Invalid
     m.mxa.cdnChangeHandler(m.top.cdn)
   end if
   m.top.ObserveField("cdn", m.messagePort)
 
-  if m.top.disableAutomaticRebufferTracking <> invalid
-    m.mxa.disableAutomaticRebufferTrackingHandler(m.top.disableAutomaticRebufferTracking)
+  if m.top.disablePlayheadRebufferTracking <> Invalid
+    m.mxa.disablePlayheadRebufferTrackingHandler(m.top.disablePlayheadRebufferTracking)
   end if
-  m.top.ObserveField("disableAutomaticRebufferTracking", m.messagePort)
+  m.top.ObserveField("disablePlayheadRebufferTracking", m.messagePort)
 
   if m.top.rebufferstart <> Invalid
     m.mxa.rebufferStartHandler(m.top.rebufferstart)
@@ -881,9 +881,9 @@ function muxAnalytics() as Object
     m._addEventToQueue(m._createEvent("error", {player_error_code: errorCode, player_error_message:errorMessage, player_error_context:errorContext, player_error_severity:errorSeverity, player_error_business_exception:isBusinessException}))
   end sub
 
-  prototype.disableAutomaticRebufferTrackingHandler = sub(disableAutomaticRebufferTracking as Boolean)
-    if disableAutomaticRebufferTracking <> Invalid
-      m._Flag_automaticRebufferTracking = (not disableAutomaticRebufferTracking)
+  prototype.disablePlayheadRebufferTrackingHandler = sub(disablePlayheadRebufferTracking as Boolean)
+    if disablePlayheadRebufferTracking <> Invalid
+      m._Flag_automaticRebufferTracking = (not disablePlayheadRebufferTracking)
     end if
   end sub
 


### PR DESCRIPTION
This PR implements the rebuffer control events for Roku analytics.

- Added `disablePlayheadRebufferTracking` field which if set to `true` will disable the automatic tracking and sending of `rebufferstart` and `rebufferend` events
- Users can now emit their own `rebufferstart` and `rebufferend` events