### PR TITLE
Renditionchange Event Parity

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -697,7 +697,7 @@ function muxAnalytics() as Object
         end if
         if videoSegment.width <> Invalid AND videoSegment.height <> Invalid AND videoSegment.segBitrateBps <> Invalid
           if m._lastSourceWidth <> Invalid AND m._lastSourceWidth <> videoSegment.width OR m._lastSourceHeight <> Invalid AND m._lastSourceHeight <> videoSegment.height OR m._lastVideoSegmentBitrate <> Invalid AND m._lastVideoSegmentBitrate <> videoSegment.segBitrateBps
-            details = { video_source_width : videoSegment.width, video_source_height : videoSegment.height, video_source_bitrate : videoSegment.segBitrateBps }
+            details = { video_source_width : videoSegment.width, video_source_height : videoSegment.height, video_source_bitrate : videoSegment.segBitrateBps, video_source_codec: m._videoSourceFormat }
             m._addEventToQueue(m._createEvent("renditionchange", details))
           end if
         end if


### PR DESCRIPTION
This PR adds the `video_source_codec` field in the `renditionchange` event so that we bring it into parity with the implementations in other SDKs. The codec field is obtained from the `videoFormat` field which is specified here [Roku docs](https://developer.roku.com/en-gb/docs/references/scenegraph/media-playback-nodes/video.md#trickplay-fields)