### PR TITLE
Cumulative Ad playing time

### DIFF
--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -14,6 +14,7 @@
     <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="true" />
     <field id="rebufferstart" type="Boolean" alwaysNotify="true" />
     <field id="rebufferend" type="Boolean" alwaysNotify="true" />
+    <field id="playback_mode" type="assocarray" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -15,6 +15,7 @@
     <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
     <field id="rebufferstart" type="Boolean" alwaysNotify="true" />
     <field id="rebufferend" type="Boolean" alwaysNotify="true" />
+    <field id="playback_mode" type="assocarray" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -960,7 +960,7 @@ function muxAnalytics() as Object
       m._addEventToQueue(m._createEvent("adimpression"))
     else if eventType = "Pause"
       if m._lastAdResumeTime <> Invalid
-        m._adWatchTime += now - m._lastAdResumeTime
+        m._adWatchTime += max(0, now - m._lastAdResumeTime)
         m._lastAdResumeTime = Invalid
       end if
       m._addEventToQueue(m._createEvent("adpause"))
@@ -992,7 +992,7 @@ function muxAnalytics() as Object
       m._addEventToQueue(m._createEvent("adplaying"))
     else if eventType = "Complete"
       if m._lastAdResumeTime <> Invalid
-        m._adWatchTime += now - m._lastAdResumeTime
+        m._adWatchTime += max(0, now - m._lastAdResumeTime)
         m._lastAdResumeTime = Invalid
       end if
       m._totalAdWatchTime += m._adWatchTime
@@ -1022,7 +1022,7 @@ function muxAnalytics() as Object
       m._addEventToQueue(m._createEvent("adthirdquartile"))
     else if eventType = "Skip"
       if m._lastAdResumeTime <> Invalid
-        m._adWatchTime += now - m._lastAdResumeTime
+        m._adWatchTime += max(0, now - m._lastAdResumeTime)
         m._lastAdResumeTime = Invalid
       end if
       m._totalAdWatchTime += m._adWatchTime
@@ -1066,7 +1066,7 @@ function muxAnalytics() as Object
         m._addEventToQueue(m._createEvent("adplaying"))
       else if state = "paused"
         if m._lastAdResumeTime <> Invalid
-          m._adWatchTime += now - m._lastAdResumeTime
+          m._adWatchTime += max(0, now - m._lastAdResumeTime)
           m._lastAdResumeTime = Invalid
         end if
         m._Flag_isPaused = true
@@ -1088,7 +1088,7 @@ function muxAnalytics() as Object
       ' Complete signals an ad has finished playback
       m._Flag_rssAdEnded = true
       if m._lastAdResumeTime <> Invalid
-        m._adWatchTime += now - m._lastAdResumeTime
+        m._adWatchTime += max(0, now - m._lastAdResumeTime)
         m._lastAdResumeTime = Invalid
       end if
       m._totalAdWatchTime += m._adWatchTime

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1054,15 +1054,16 @@ function muxAnalytics() as Object
         m._Flag_isPaused = false
         m._addEventToQueue(m._createEvent("adplay"))
       else if state = "playing"
-        ' in the playing state, if we either resuming, we need adplay first
+        ' in the playing state, if we are resuming, we need adplay first
         if m._Flag_isPaused
           m._Flag_isPaused = false
-          m._lastAdResumeTime = now
           m._addEventToQueue(m._createEvent("adplay"))
+        else
+          ' starting fresh: reset watch time
+          m._adWatchTime = 0
         end if
         ' and always emit adplaying
-          m._adWatchTime = 0
-          m._lastAdResumeTime = now
+        m._lastAdResumeTime = now
         m._addEventToQueue(m._createEvent("adplaying"))
       else if state = "paused"
         if m._lastAdResumeTime <> Invalid

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -2127,7 +2127,7 @@ function muxAnalytics() as Object
     "current": "cu",
     "connection": "cx",
     "context": "cz",
-    "cumulative": "cm",
+    "cumulative": "cv",
     "downscaling": "dg",
     "domain": "dm",
     "cdn": "dn",

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -939,8 +939,6 @@ function muxAnalytics() as Object
 
     m._Flag_isPaused = (eventType = "Pause")
     if eventType = "PodStart"
-      m._adWatchTime = 0
-      m._lastAdResumeTime = now
       m._advertProperties = m._getAdvertProperties(adMetadata)
       m._addEventToQueue(m._createEvent("adbreakstart"))
       ' In the case that this is SSAI, we need to signal an adplay and adplaying event
@@ -949,11 +947,6 @@ function muxAnalytics() as Object
         m._addEventToQueue(m._createEvent("adplaying"))
       end if
     else if eventType = "PodComplete"
-      if m._lastAdResumeTime <> Invalid
-        m._adWatchTime += now - m._lastAdResumeTime
-        m._lastAdResumeTime = Invalid
-      end if
-      m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adbreakend"))
       m._Flag_FailedAdsErrorSet = false
       ' In the case that this is SSAI, we need to signal a play and playing event
@@ -987,6 +980,8 @@ function muxAnalytics() as Object
         m._viewPrerollPlayedCount++
       end if
       m._advertProperties = m._getAdvertProperties(ctx)
+      m._adWatchTime = 0
+      m._lastAdResumeTime = now
       m._addEventToQueue(m._createEvent("adplay"))
       m._addEventToQueue(m._createEvent("adplaying"))
     else if eventType = "Resume"
@@ -995,6 +990,11 @@ function muxAnalytics() as Object
       m._addEventToQueue(m._createEvent("adplay"))
       m._addEventToQueue(m._createEvent("adplaying"))
     else if eventType = "Complete"
+      if m._lastAdResumeTime <> Invalid
+        m._adWatchTime += now - m._lastAdResumeTime
+        m._lastAdResumeTime = Invalid
+      end if
+      m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adended"))
     else if eventType = "NoAdsError"
       if m._Flag_FailedAdsErrorSet <> true
@@ -1046,8 +1046,6 @@ function muxAnalytics() as Object
         ' our ad break here if we're not already in one
         if not m._Flag_rssInAdBreak
           m._Flag_rssInAdBreak = true
-          m._adWatchTime = 0
-          m._lastAdResumeTime = now
           m._addEventToQueue(m._createEvent("adbreakstart"))
         end if
 
@@ -1062,6 +1060,8 @@ function muxAnalytics() as Object
           m._addEventToQueue(m._createEvent("adplay"))
         end if
         ' and always emit adplaying
+          m._adWatchTime = 0
+          m._lastAdResumeTime = now
         m._addEventToQueue(m._createEvent("adplaying"))
       else if state = "paused"
         if m._lastAdResumeTime <> Invalid
@@ -1086,6 +1086,11 @@ function muxAnalytics() as Object
     else if eventType = "Complete"
       ' Complete signals an ad has finished playback
       m._Flag_rssAdEnded = true
+      if m._lastAdResumeTime <> Invalid
+        m._adWatchTime += now - m._lastAdResumeTime
+        m._lastAdResumeTime = Invalid
+      end if
+      m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adended"))
     else if eventType = "Impression"
       ' When an additional ad is played within an ad pod, we do not get
@@ -1098,11 +1103,6 @@ function muxAnalytics() as Object
         m._addEventToQueue(m._createEvent("adplaying"))
       end if
     else if eventType = "PodComplete"
-      if m._lastAdResumeTime <> Invalid
-        m._adWatchTime += now - m._lastAdResumeTime
-        m._lastAdResumeTime = Invalid
-      end if
-      m._totalAdWatchTime += m._adWatchTime
       m._Flag_rssInAdBreak = false
       m._Flag_isPaused = true
       m._addEventToQueue(m._createEvent("adbreakend"))

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1751,7 +1751,7 @@ function muxAnalytics() as Object
       props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
     end if
     if m._totalAdWatchTime <> Invalid AND m._totalAdWatchTime > 0
-      props.ad_playing_time_active_ms_cumulative = m._totalAdWatchTime
+      props.ad_playing_time_ms_cumulative = m._totalAdWatchTime
     end if
     if m._configProperties <> Invalid AND m._configProperties.player_init_time <> Invalid
       playerInitTime = Invalid
@@ -2101,7 +2101,6 @@ function muxAnalytics() as Object
     "asset": "as",
     "autoplay": "au",
     "average": "av",
-    "active": "ac",
     "bitrate": "bi",
     "brand": "bn",
     "break": "br",

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -943,6 +943,7 @@ function muxAnalytics() as Object
       m._addEventToQueue(m._createEvent("adbreakstart"))
       ' In the case that this is SSAI, we need to signal an adplay and adplaying event
       if m._Flag_useSSAI = true
+        m._lastAdResumeTime = now
         m._addEventToQueue(m._createEvent("adplay"))
         m._addEventToQueue(m._createEvent("adplaying"))
       end if

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -415,6 +415,7 @@ function muxAnalytics() as Object
     m._totalAdWatchTime = Invalid
     m._adWatchTime = Invalid
     m._cumulativePlayingTime = Invalid
+    m._lastAdResumeTime = Invalid
 
     m._lastSourceWidth = Invalid
     m._lastSourceHeight = Invalid
@@ -1326,7 +1327,6 @@ function muxAnalytics() as Object
       m._viewId = m._generateGUID()
       m._viewWatchTime = 0
       m._adWatchTime = 0
-      m._lastAdResumeTime = Invalid
       m._totalAdWatchTime = 0
       m._cumulativePlayingTime = 0
       m._contentPlaybackTime = 0
@@ -1386,6 +1386,7 @@ function muxAnalytics() as Object
       m._adWatchTime = Invalid
       m._lastAdResumeTime = Invalid
       m._totalAdWatchTime = Invalid
+      m._cumulativePlayingTime = Invalid
       m._viewRebufferCount = Invalid
       m._viewRebufferDuration = Invalid
       m._viewRebufferFrequency! = Invalid

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1100,6 +1100,7 @@ function muxAnalytics() as Object
       ' event to know that a new ad was played
       if m._Flag_rssAdEnded
         m._Flag_rssAdEnded = false
+        m._adWatchTime = 0
         m._lastAdResumeTime = now
         m._addEventToQueue(m._createEvent("adplay"))
         m._addEventToQueue(m._createEvent("adplaying"))

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -949,7 +949,7 @@ function muxAnalytics() as Object
         m._adWatchTime += now - m._lastAdResumeTime
         m._lastAdResumeTime = Invalid
       end if
-      print "Total ads watch time this break: "; m._adWatchTime; " ms"
+      m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adbreakend"))
       m._Flag_FailedAdsErrorSet = false
       ' In the case that this is SSAI, we need to signal a play and playing event
@@ -1020,7 +1020,7 @@ function muxAnalytics() as Object
         m._adWatchTime += now - m._lastAdResumeTime
         m._lastAdResumeTime = Invalid
       end if
-      print "Total ads watch time: "; m._adWatchTime; " ms"
+      m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adskipped"))
       m._addEventToQueue(m._createEvent("adended"))
     end if
@@ -1081,11 +1081,6 @@ function muxAnalytics() as Object
       end if
     else if eventType = "Complete"
       ' Complete signals an ad has finished playback
-      if m._lastAdResumeTime <> Invalid
-        m._adWatchTime += now - m._lastAdResumeTime
-        m._lastAdResumeTime = Invalid
-      end if
-      print "Total ads watch time: "; m._adWatchTime; " ms"
       m._Flag_rssAdEnded = true
       m._addEventToQueue(m._createEvent("adended"))
     else if eventType = "Impression"
@@ -1103,6 +1098,7 @@ function muxAnalytics() as Object
         m._adWatchTime += now - m._lastAdResumeTime
         m._lastAdResumeTime = Invalid
       end if
+      m._totalAdWatchTime += m._adWatchTime
       m._Flag_rssInAdBreak = false
       m._Flag_isPaused = true
       m._addEventToQueue(m._createEvent("adbreakend"))
@@ -1327,6 +1323,7 @@ function muxAnalytics() as Object
       m._viewWatchTime = 0
       m._adWatchTime = 0
       m._lastAdResumeTime = Invalid
+      m._totalAdWatchTime = 0
       m._contentPlaybackTime = 0
       m._viewRebufferCount = 0
       m._viewRebufferDuration = 0
@@ -1383,6 +1380,7 @@ function muxAnalytics() as Object
       m._viewWatchTime = Invalid
       m._adWatchTime = Invalid
       m._lastAdResumeTime = Invalid
+      m._totalAdWatchTime = Invalid
       m._viewRebufferCount = Invalid
       m._viewRebufferDuration = Invalid
       m._viewRebufferFrequency! = Invalid

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -412,6 +412,9 @@ function muxAnalytics() as Object
     m._videoSourceDuration = Invalid
     m._videoCurrentCdn = Invalid
     m._viewPrerollPlayedCount = Invalid
+    m._totalAdWatchTime = Invalid
+    m._adWatchTime = Invalid
+    m._cumulativePlayingTime = Invalid
 
     m._lastSourceWidth = Invalid
     m._lastSourceHeight = Invalid
@@ -1185,6 +1188,7 @@ function muxAnalytics() as Object
     if m._contentPlaybackTime = Invalid then return
 
     m._viewWatchTime = m._viewTimeToFirstFrame + m._viewRebufferDuration + m._contentPlaybackTime
+    m._cumulativePlayingTime = m._viewWatchTime + m._totalAdWatchTime
   end sub
 
   prototype._setBufferingMetrics = sub()
@@ -1324,6 +1328,7 @@ function muxAnalytics() as Object
       m._adWatchTime = 0
       m._lastAdResumeTime = Invalid
       m._totalAdWatchTime = 0
+      m._cumulativePlayingTime = 0
       m._contentPlaybackTime = 0
       m._viewRebufferCount = 0
       m._viewRebufferDuration = 0
@@ -1741,6 +1746,12 @@ function muxAnalytics() as Object
     if m._viewRequestCount <> Invalid
       props.view_request_count = m._viewRequestCount
     end if
+    if m._cumulativePlayingTime <> Invalid AND m._cumulativePlayingTime > 0
+      props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
+    end if
+    if m._totalAdWatchTime <> Invalid AND m._totalAdWatchTime > 0
+      props.ad_playing_time_active_ms_cumulative = m._totalAdWatchTime
+    end if
     if m._configProperties <> Invalid AND m._configProperties.player_init_time <> Invalid
       playerInitTime = Invalid
       if Type(m._configProperties.player_init_time) = "roString"
@@ -2089,6 +2100,7 @@ function muxAnalytics() as Object
     "asset": "as",
     "autoplay": "au",
     "average": "av",
+    "active": "ac",
     "bitrate": "bi",
     "brand": "bn",
     "break": "br",
@@ -2115,6 +2127,7 @@ function muxAnalytics() as Object
     "current": "cu",
     "connection": "cx",
     "context": "cz",
+    "cumulative": "cm",
     "downscaling": "dg",
     "domain": "dm",
     "cdn": "dn",
@@ -2176,6 +2189,7 @@ function muxAnalytics() as Object
     "manufacturer": "mn",
     "model": "mo",
     "mux": "mx",
+    "ms": "ms",
     "newest": "ne",
     "name": "nm",
     "number": "no",


### PR DESCRIPTION
This PR implements tracking of ad watch time and calculation of cumulative watch time (watch time of content + ads and watch time of ads)

Due to not having the possibility of tracking playhead time on ads, the calculation of ad watch time is done using wall clock comparisons, tracking the start and end of the ads and calculating the difference (without taking into account the pauses and rebuffers)

The cumulative time ad is sent as `ad_playing_time_active_ms_cumulative`
The cumulative time of content + ads is sent as `view_playing_time_ms_cumulative`