### PR TITLE
Playback Mode Field

### DIFF
--- a/sampleapp_source/components_recycled/components/MuxTask.xml
+++ b/sampleapp_source/components_recycled/components/MuxTask.xml
@@ -14,6 +14,7 @@
     <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="true" />
     <field id="rebufferstart" type="Boolean" alwaysNotify="true" />
     <field id="rebufferend" type="Boolean" alwaysNotify="true" />
+    <field id="playback_mode" type="assocarray" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/sampleapp_source/components_reset/components/MuxTask.xml
+++ b/sampleapp_source/components_reset/components/MuxTask.xml
@@ -15,6 +15,7 @@
     <field id="disablePlayheadRebufferTracking" type="Boolean" alwaysNotify="true" value="false" />
     <field id="rebufferstart" type="Boolean" alwaysNotify="true" />
     <field id="rebufferend" type="Boolean" alwaysNotify="true" />
+    <field id="playback_mode" type="assocarray" alwaysNotify="true" />
   </interface>
   <script type="text/brightscript" uri="pkg:/libs/mux-analytics.brs"/>
 </component>

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -908,8 +908,25 @@ function muxAnalytics() as Object
 
   prototye.playbackModeHandler = sub(playbackMode as Object)
     props = {}
+
+    if playbackMode.mode = Invalid
+      print "[mux-analytics] warning: playback_mode mode property not set."
+      return
+    end if
     props.player_playback_mode = playbackMode.mode
+
+    if playbackMode.player_playback_mode_data = Invalid
+      print "[mux-analytics] warning: playback_mode player_playback_mode_data property not set."
+      return
+    end if
+
+    parsedData = ParseJson(playbackMode.player_playback_mode_data)
+    if parsedData = Invalid then
+      print "[mux-analytics] warning: player_playback_mode_data is not valid JSON"
+      return
+    end if
     props.player_playback_mode_data = playbackMode.player_playback_mode_data
+
     props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
     props.ad_playing_time_ms_cumulative = m._totalAdWatchTime
 

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -914,11 +914,11 @@ function muxAnalytics() as Object
   prototype.playbackModeHandler = sub(playbackMode as Object)
     props = {}
 
-    if playbackMode.mode = Invalid
-      print "[mux-analytics] warning: playback_mode mode property not set."
+    if playbackMode.player_playback_mode = Invalid
+      print "[mux-analytics] warning: playback_mode player_playback_mode property not set."
       return
     end if
-    props.player_playback_mode = playbackMode.mode
+    props.player_playback_mode = playbackMode.player_playback_mode
 
     if playbackMode.player_playback_mode_data <> Invalid
       ' ParseJson returns invalid if provided string is not parse-able JSON

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -931,7 +931,7 @@ function muxAnalytics() as Object
     props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
     props.ad_playing_time_ms_cumulative = m._totalAdWatchTime
 
-    m._addEventToQueue(m._createEvent("playbackmodechange"), props)
+    m._addEventToQueue(m._createEvent("playbackmodechange", props))
   end sub
 
   prototype.rafEventHandler = sub(rafEvent)

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -920,6 +920,7 @@ function muxAnalytics() as Object
       return
     end if
 
+    ' ParseJson returns invalid if provided string is not parse-able JSON
     parsedData = ParseJson(playbackMode.player_playback_mode_data)
     if parsedData = Invalid then
       print "[mux-analytics] warning: player_playback_mode_data is not valid JSON"

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1396,6 +1396,13 @@ function muxAnalytics() as Object
         m._videoProperties = m._getVideoProperties(m.video)
       end if
 
+      ' Send playbackmodechange event
+      props = {}
+      props.player_playback_mode = "standard"
+      props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
+      props.ad_playing_time_ms_cumulative = m._totalAdWatchTime
+      m._addEventToQueue(m._createEvent("playbackmodechange", props))
+
       m._addEventToQueue(m._createEvent("viewstart"))
 
       m._inView = true

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -212,6 +212,8 @@ function runBeaconLoop()
           m.mxa.rebufferStartHandler()
         else if field = "rebufferend"
           m.mxa.rebufferEndHandler()
+        else if field = "playback_mode"
+          m.mxa.playbackModeHandler()
         end if
       end if
     end if
@@ -902,6 +904,16 @@ function muxAnalytics() as Object
 
   prototype.rebufferEndHandler = sub()
     m._addEventToQueue(m._createEvent("rebufferend"))
+  end sub
+
+  prototye.playbackModeHandler = sub(playbackMode as Object)
+    props = {}
+    props.player_playback_mode = playbackMode.mode
+    props.player_playback_mode_data = playbackMode.player_playback_mode_data
+    props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
+    props.ad_playing_time_ms_cumulative = m._totalAdWatchTime
+
+    m._addEventToQueue(m._createEvent("playbackmodechange"), props)
   end sub
 
   prototype.rafEventHandler = sub(rafEvent)


### PR DESCRIPTION
This PR adds a new field called `playback_mode` which accepts an assocarray

This field is handled in the `playbackModeHandler `, this method does the following:

- Checks if the property `mode` is set, if not, it warns the user and returns
- Checks if the property `player_playback_mode_data` is set, if not, it warns the user and returns
- Checks if the property `player_playback_mode_data` is parse-able JSON, if not, it warns the user and returns
- Sends the event `playbackmodechange` containing `mode`, `player_playback_mode_data`, `m._cumulativePlayingTime` and `m._totalAdWatchTime`

To check if a string is parse-able JSON, the `ParseJson` utility function was used, to check out how it works, here's the [documentation](https://developer.roku.com/en-gb/docs/references/brightscript/language/global-utility-functions.md#parsejsonjsonstring-as-string-flags---as-string-as-object)