### PR TITLE
Playbackmodechange event before viewstart

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1397,6 +1397,7 @@ function muxAnalytics() as Object
       end if
 
       ' Send playbackmodechange event
+      props = {}
       props.player_playback_mode = "standard"
       props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
       props.ad_playing_time_ms_cumulative = m._totalAdWatchTime

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1394,6 +1394,12 @@ function muxAnalytics() as Object
         m._videoProperties = m._getVideoProperties(m.video)
       end if
 
+      ' Send playbackmodechange event
+      props.player_playback_mode = "standard"
+      props.view_playing_time_ms_cumulative = m._cumulativePlayingTime
+      props.ad_playing_time_ms_cumulative = m._totalAdWatchTime
+      m._addEventToQueue(m._createEvent("playbackmodechange", props))
+
       m._addEventToQueue(m._createEvent("viewstart"))
 
       m._inView = true


### PR DESCRIPTION
This PR implements logic to emit the `playbackmodechange` event before we emit the `viewstart` event.

On this `playbackmodechange` event we send:
- `player_playback_mode` as "standard"
- `view_playing_time_ms_cumulative` with `m._cumulativePlayingTime`
- `ad_playing_time_ms_cumulative` with `m._totalAdWatchTime`

I'm not quite sure if we want to send the cumulative times, I added them just in case (and because we send them on the other `playbackmodechange`)