### PR TITLE
Release v2.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.2",
+  "version": "2.6.3",
   "main": "./src/mux-analytics.brs",
   "dependencies": {
     "@rokucommunity/bslint": "^0.8.9",

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "2.6.2"
+  m.MUX_SDK_VERSION = "2.6.3"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
   


### PR DESCRIPTION
## Summary
- Bump SDK version from 2.6.2 to 2.6.3 in `package.json` and `src/mux-analytics.brs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-string-only change; functional behavior is unaffected aside from reported/packaged version metadata.
> 
> **Overview**
> **Release bump to v2.6.3.** Updates the version in `package.json` and the `m.MUX_SDK_VERSION` constant in `src/mux-analytics.brs` from `2.6.2` to `2.6.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4de78dbe2ba9df554e28916f9a36bb25f2602b95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->