### PR TITLE
Fix late video node binding

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -66,9 +66,7 @@ function runBeaconLoop()
 
   m.top.ObserveField("rafEvent", m.messagePort)
 
-  if m.top.video = Invalid
-    m.top.ObserveField("video", m.messagePort)
-  else
+  bindVideoNode = sub()
     for each fieldName in m.mxa.videoNodeFieldsToObserve()
       m.top.video.ObserveField(fieldName, m.messagePort)
     end for
@@ -84,6 +82,12 @@ function runBeaconLoop()
       m.top.video.enableDecoderStats = true
       m.top.video.ObserveField("decoderStats", m.messagePort)
     end if
+  end sub
+
+  if m.top.video <> Invalid
+    bindVideoNode(m.top.video)
+  else
+    m.top.ObserveField("video", m.messagePort)
   end if
 
   if m.top.view <> Invalid AND m.top.view <> ""
@@ -197,24 +201,10 @@ function runBeaconLoop()
         if m.mxa.isObservedVideoNodeField(field)
           m.mxa.videoNodeFieldChangeHandler(field, msg.getData())
         else if field = "video"
-          if m.top.video = Invalid
+          video = msg.getData()
+          if video <> Invalid
             m.top.UnobserveField("video")
-            data = msg.getData()
-            for each fieldName in m.mxa.videoNodeFieldsToObserve()
-              m.top.video.ObserveField(fieldName, m.messagePort)
-            end for
-            m.mxa.videoAddedHandler(data)
-            m.top.video.ObserveField("content", m.messagePort)
-            m.top.video.ObserveField("control", m.messagePort)
-            m.top.video.ObserveField("licenseStatus", m.messagePort)
-            m.top.video.ObserveField("contentIndex", m.messagePort)
-            m.top.video.ObserveField("downloadedSegment", m.messagePort)
-            m.top.video.ObserveField("streamingSegment", m.messagePort)
-            m.top.video.ObserveField("position", m.messagePort)
-            if m.top.disableDecoderStats <> true AND m.top.video.enableDecoderStats <> Invalid
-              m.top.video.enableDecoderStats = true
-              m.top.video.ObserveField("decoderStats", m.messagePort)
-            end if
+            bindVideoNode(video)
           end if
         else if field = "config"
           m.mxa.configChangeHandler(msg.getData())

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -66,21 +66,21 @@ function runBeaconLoop()
 
   m.top.ObserveField("rafEvent", m.messagePort)
 
-  bindVideoNode = sub()
+  bindVideoNode = sub(video as Object)
     for each fieldName in m.mxa.videoNodeFieldsToObserve()
-      m.top.video.ObserveField(fieldName, m.messagePort)
+      video.ObserveField(fieldName, m.messagePort)
     end for
-    m.mxa.videoAddedHandler(m.top.video)
-    m.top.video.ObserveField("content", m.messagePort)
-    m.top.video.ObserveField("control", m.messagePort)
-    m.top.video.ObserveField("licenseStatus", m.messagePort)
-    m.top.video.ObserveField("contentIndex", m.messagePort)
-    m.top.video.ObserveField("downloadedSegment", m.messagePort)
-    m.top.video.ObserveField("streamingSegment", m.messagePort)
-    m.top.video.ObserveField("position", m.messagePort)
-    if m.top.disableDecoderStats <> true AND m.top.video.enableDecoderStats <> Invalid
-      m.top.video.enableDecoderStats = true
-      m.top.video.ObserveField("decoderStats", m.messagePort)
+    m.mxa.videoAddedHandler(video)
+    video.ObserveField("content", m.messagePort)
+    video.ObserveField("control", m.messagePort)
+    video.ObserveField("licenseStatus", m.messagePort)
+    video.ObserveField("contentIndex", m.messagePort)
+    video.ObserveField("downloadedSegment", m.messagePort)
+    video.ObserveField("streamingSegment", m.messagePort)
+    video.ObserveField("position", m.messagePort)
+    if m.top.disableDecoderStats <> true AND video.enableDecoderStats <> Invalid
+      video.enableDecoderStats = true
+      video.ObserveField("decoderStats", m.messagePort)
     end if
   end sub
 


### PR DESCRIPTION
This feature allowing late attachment of the video node was behind an if statement checking the wrong condition. This PR fixes that and wraps the setup code in a `sub` for reuse.

Resolves [NAT-434].

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor/fix confined to video-node observation wiring; main risk is missed/duplicate analytics events if binding conditions are still off in edge cases.
> 
> **Overview**
> Fixes late `video` node attachment in `mux-analytics.brs` by correcting the initial binding condition: when `m.top.video` is already set, the task now immediately binds and observes it; otherwise it observes the `video` field and binds when it becomes available.
> 
> The repeated “observe fields + enable decoder stats” setup is extracted into a reusable `bindVideoNode(video)` sub and invoked from both startup and the `video` field-change handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9591b406a28cdd4016df6ae92f69eed42374e80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[NAT-434]: https://mux1.atlassian.net/browse/NAT-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ