### PR TITLE
NAT-378: Exclude rebuffering from Roku cumulative playing time

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1654,7 +1654,7 @@ function muxAnalytics() as Object
     if m._contentPlaybackTime = Invalid then return
 
     m._viewWatchTime = m._viewTimeToFirstFrame + m._viewRebufferDuration + m._contentPlaybackTime
-    m._cumulativePlayingTime = m._viewWatchTime + m._totalAdWatchTime
+    m._cumulativePlayingTime = m._contentPlaybackTime + m._totalAdWatchTime
   end sub
 
   prototype._setBufferingMetrics = sub()

--- a/test/source_tests/source/tests/Test__View_Robustness.brs
+++ b/test/source_tests/source/tests/Test__View_Robustness.brs
@@ -26,6 +26,7 @@ Function TestSuite__ViewRobustness() as Object
   this.addTest("ViewRobustness [9] Internally Started", TestCase__MuxAnalytics_ViewRobustness_internal_start_9, ViewRobustness_SetUp)
   this.addTest("ViewRobustness [10] Internally Started", TestCase__MuxAnalytics_ViewRobustness_internal_start_10, ViewRobustness_SetUp)
   this.addTest("ViewRobustness [10] Internally Ended", TestCase__MuxAnalytics_ViewRobustness_internal_end_1)
+  this.addTest("ViewRobustness cumulative playing time excludes startup and rebuffer", TestCase__MuxAnalytics_ViewRobustness_playing_time_excludes_startup_and_rebuffer)
 
   return this
 End Function
@@ -321,6 +322,21 @@ Function TestCase__MuxAnalytics_ViewRobustness_internal_end_1() as String
   return m.assertEqual("viewstartplayviewend", result)
 End Function
 
+Function TestCase__MuxAnalytics_ViewRobustness_playing_time_excludes_startup_and_rebuffer() as String
+  m.SUT.video_state = "playing"
+  m.SUT._viewWatchTime = 0
+  m.SUT._viewStartTimestamp = 1
+  m.SUT._viewTimeToFirstFrame = 1000
+  m.SUT._viewRebufferDuration = 4000
+  m.SUT._contentPlaybackTime = 10000
+  m.SUT._totalAdWatchTime = 2000
 
+  m.SUT._updateTotalWatchTime()
 
+  if m.SUT._viewWatchTime <> 15000
+    return m.assertEqual(15000, m.SUT._viewWatchTime)
+  end if
+
+  return m.assertEqual(12000, m.SUT._cumulativePlayingTime)
+End Function
 


### PR DESCRIPTION
## Summary
- update Roku cumulative playing time so it counts content playback plus ad playback, excluding startup and rebuffer time
- keep view watch time unchanged so watch time still includes startup/rebuffer as before
- add a source regression test for the cumulative playing-time calculation

## Context
The dashboard Playing Time metric is not the validation surface for this bug. Data checked the raw backend database event field for Roku test views and confirmed that pre-fix `events.view_playing_time_ms_cumulative` increased during rebuffer intervals. After this fix, the same field stayed flat during rebuffer intervals.

## Validation
- Manual Roku/dashboard test after fix: rebuffer duration was reported while dashboard Playing Time stayed separate
- Data validation in backend database: post-fix `events.view_playing_time_ms_cumulative` stayed flat during rebuffer intervals



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how a core analytics field is computed and beaconed; behavior is intentional and covered by a unit test, but downstream metrics that relied on the old (buggy) values will differ.
> 
> **Overview**
> Fixes Roku **cumulative playing time** (`view_playing_time_ms_cumulative`) so it no longer grows during startup or rebuffer. **`_updateTotalWatchTime`** now sets `_cumulativePlayingTime` from **content playback + ad watch time** only, instead of deriving it from `_viewWatchTime` (which still includes time-to-first-frame and rebuffer).
> 
> **View watch time** is unchanged: it remains startup + rebuffer + content playback. A **ViewRobustness** source test asserts that with fixed inputs, watch time stays 15s while cumulative playing time is 12s (10s content + 2s ads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db498176f1e6ef44f502cdf33e9eef9ec8737f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->