### PR TITLE
Release v2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.3",
+  "version": "2.7.0",
   "main": "./src/mux-analytics.brs",
   "dependencies": {
     "@rokucommunity/bslint": "^0.8.9",

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "2.6.3"
+  m.MUX_SDK_VERSION = "2.7.0"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
   


### PR DESCRIPTION
## Summary
- bump SDK version from 2.6.3 to 2.7.0 in package.json and src/mux-analytics.brs

## Included since v2.6.3
- NAT-390: texttrackchange events (#117)
- Fix Roku cumulative playing time (#119)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string bumps only; no runtime logic changes in this diff.
> 
> **Overview**
> **Release v2.7.0** bumps the published SDK version from **2.6.3** to **2.7.0** in `package.json` and sets `m.MUX_SDK_VERSION` in `src/mux-analytics.brs` `init()` to match, so beacon/session metadata reports the new release.
> 
> The PR description notes this tag ships prior work since v2.6.3 (e.g. `texttrackchange` events and cumulative playing time fixes); those behaviors are **not** in this diff—only the version alignment changes here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053ab145a16b4405d8a82cd2c942963aab031d35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->