### PR TITLE
NAT-435: Suppress content playback events while Roku ads are active

### DIFF
--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -582,6 +582,9 @@ function muxAnalytics() as Object
     m._Flag_useSSAI = false
     m._Flag_automaticErrorTracking = true
     m._Flag_automaticRebufferTracking = true
+    m._Flag_adPlaybackActive = false
+    m._Flag_rafInAdBreak = false
+    m._Flag_deferredContentPlayingAfterAd = false
 
     ' Flags specifically for when renderStitchedStream is used
     m._Flag_useRenderStitchedStream = false
@@ -848,7 +851,7 @@ function muxAnalytics() as Object
 
         ' We will emit the play from paused states further down if needed
         if m._Flag_lastVideoState <> "paused"
-          m._addEventToQueue(m._createEvent("play"))
+          m._triggerPlayEvent()
         end if
       end if
 
@@ -861,19 +864,18 @@ function muxAnalytics() as Object
           end if
         end if
       end if
-      if m._Flag_lastVideoState = "paused"
-        m._addEventToQueue(m._createEvent("play"))
-      end if
+      if m._isAdPlaybackActive()
+        m._Flag_deferredContentPlayingAfterAd = true
+      else
+        m._Flag_deferredContentPlayingAfterAd = false
+        if m._Flag_lastVideoState = "paused"
+          m._triggerPlayEvent()
+        end if
 
-      ' if we haven't gotten any playhead updates yet, don't try to start a range
-      if m._playerPlayheadTime <> Invalid
-        m._startPlaybackRange(m._playerPlayheadTime)
+        m._emitContentPlayingEvent()
       end if
-
-      m._addEventToQueue(m._createEvent("playing"))
 
       m._Flag_isSeeking = false
-      m._Flag_atLeastOnePlayEventForContent = true
     else if videoState = "stopped"
     else if videoState = "finished"
       ' Only send ended event if it played to completion
@@ -1024,6 +1026,11 @@ function muxAnalytics() as Object
   end function
 
   prototype._triggerPlayEvent = sub()
+    if m._isAdPlaybackActive()
+      m._Flag_deferredContentPlayingAfterAd = true
+      return
+    end if
+
     if m.video <> Invalid
       if m.video.content <> Invalid
         if m.video.contentIsPlaylist
@@ -1035,6 +1042,51 @@ function muxAnalytics() as Object
       m._videoProperties = m._getVideoProperties(m.video)
     end if
     m._addEventToQueue(m._createEvent("play"))
+  end sub
+
+  prototype._emitContentPlayingEvent = sub()
+    ' if we haven't gotten any playhead updates yet, don't try to start a range
+    if m._playerPlayheadTime <> Invalid
+      m._startPlaybackRange(m._playerPlayheadTime)
+    end if
+
+    m._addEventToQueue(m._createEvent("playing"))
+
+    m._Flag_atLeastOnePlayEventForContent = true
+  end sub
+
+  prototype._isAdPlaybackActive = function() as Boolean
+    return m._Flag_adPlaybackActive = true OR m._Flag_rafInAdBreak = true OR m._Flag_rssInAdBreak = true
+  end function
+
+  prototype._beginAdPlayback = sub()
+    m._Flag_adPlaybackActive = true
+  end sub
+
+  prototype._endAdPlayback = sub()
+    m._Flag_adPlaybackActive = false
+    m._emitDeferredContentPlayingAfterAd()
+  end sub
+
+  prototype._emitDeferredContentPlayingAfterAd = sub()
+    if m._Flag_deferredContentPlayingAfterAd <> true
+      return
+    end if
+    if m._isAdPlaybackActive()
+      return
+    end if
+
+    currentVideoState = m.video_state
+    if m.video <> Invalid AND m.video.state <> Invalid
+      currentVideoState = m.video.state
+    end if
+    if currentVideoState <> "playing"
+      return
+    end if
+
+    m._Flag_deferredContentPlayingAfterAd = false
+    m._triggerPlayEvent()
+    m._emitContentPlayingEvent()
   end sub
 
   prototype.videoControlChangeHandler = sub(control as String)
@@ -1534,10 +1586,12 @@ function muxAnalytics() as Object
 
     m._Flag_isPaused = (eventType = "Pause")
     if eventType = "PodStart"
+      m._Flag_rafInAdBreak = true
       m._advertProperties = m._getAdvertProperties(adMetadata)
       m._addEventToQueue(m._createEvent("adbreakstart"))
       ' In the case that this is SSAI, we need to signal an adplay and adplaying event
       if m._Flag_useSSAI = true
+        m._beginAdPlayback()
         m._lastAdResumeTime = now
         m._addEventToQueue(m._createEvent("adplay"))
         m._addEventToQueue(m._createEvent("adplaying"))
@@ -1548,17 +1602,24 @@ function muxAnalytics() as Object
     else if eventType = "PodComplete"
       m._addEventToQueue(m._createEvent("adbreakend"))
       m._Flag_FailedAdsErrorSet = false
+      m._Flag_rafInAdBreak = false
       ' In the case that this is SSAI, we need to signal a play and playing event
       if m._Flag_useSSAI = true
-        m._Flag_isPaused = false
-        m._triggerPlayEvent()
- 
-        m._addEventToQueue(m._createEvent("playing"))
+        hadDeferredContentPlaying = m._Flag_deferredContentPlayingAfterAd = true
+        m._endAdPlayback()
+        emittedDeferredContentPlaying = hadDeferredContentPlaying AND m._Flag_deferredContentPlayingAfterAd <> true
+        if emittedDeferredContentPlaying <> true
+          m._Flag_isPaused = false
+          m._triggerPlayEvent()
+
+          m._addEventToQueue(m._createEvent("playing"))
+        end if
       else 
         ' for CSAI, we need to restart the playback range
         if m._Flag_isPaused <> false 
           m._startPlaybackRange(m._playerPlayheadTime)
         end if
+        m._endAdPlayback()
       end if
     else if eventType = "Impression"
       m._addEventToQueue(m._createEvent("adimpression"))
@@ -1586,11 +1647,13 @@ function muxAnalytics() as Object
       end if
       m._advertProperties = m._getAdvertProperties(ctx)
       m._adWatchTime = 0
+      m._beginAdPlayback()
       m._lastAdResumeTime = now
 
       m._addEventToQueue(m._createEvent("adplay"))
       m._addEventToQueue(m._createEvent("adplaying"))
     else if eventType = "Resume"
+      m._beginAdPlayback()
       m._lastAdResumeTime = now
       m._advertProperties = m._getAdvertProperties(ctx)
 
@@ -1604,6 +1667,9 @@ function muxAnalytics() as Object
 
       m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adended"))
+      if m._Flag_rafInAdBreak <> true
+        m._endAdPlayback()
+      end if
     else if eventType = "NoAdsError"
       if m._Flag_FailedAdsErrorSet <> true
         ' For now, aderror events do not support codes and messages, but leaving
@@ -1635,6 +1701,9 @@ function muxAnalytics() as Object
       m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adskipped"))
       m._addEventToQueue(m._createEvent("adended"))
+      if m._Flag_rafInAdBreak <> true
+        m._endAdPlayback()
+      end if
     end if
   end sub
 
@@ -1658,6 +1727,7 @@ function muxAnalytics() as Object
         ' our ad break here if we're not already in one
         if not m._Flag_rssInAdBreak
           m._Flag_rssInAdBreak = true
+          m._beginAdPlayback()
 
           m._addEventToQueue(m._createEvent("adbreakstart"))
         end if
@@ -1676,6 +1746,7 @@ function muxAnalytics() as Object
           m._adWatchTime = 0
         end if
         ' and always emit adplaying
+        m._beginAdPlayback()
         m._lastAdResumeTime = now
         m._addEventToQueue(m._createEvent("adplaying"))
       else if state = "paused"
@@ -1690,6 +1761,7 @@ function muxAnalytics() as Object
       ' Need to handle PodStart for non-pre-rolls
       if not m._Flag_rssInAdBreak
         m._Flag_rssInAdBreak = true
+        m._beginAdPlayback()
         m._adWatchTime = 0
         m._lastAdResumeTime = now
         if not m._Flag_isPaused
@@ -1709,6 +1781,7 @@ function muxAnalytics() as Object
 
       m._totalAdWatchTime += m._adWatchTime
       m._addEventToQueue(m._createEvent("adended"))
+      m._endAdPlayback()
     else if eventType = "Impression"
       ' When an additional ad is played within an ad pod, we do not get
       ' the AdStateChange events or anything other than the Impression
@@ -1716,6 +1789,7 @@ function muxAnalytics() as Object
       if m._Flag_rssAdEnded
         m._Flag_rssAdEnded = false
         m._adWatchTime = 0
+        m._beginAdPlayback()
         m._lastAdResumeTime = now
 
         m._addEventToQueue(m._createEvent("adplay"))
@@ -1726,6 +1800,7 @@ function muxAnalytics() as Object
       m._Flag_isPaused = true
 
       m._addEventToQueue(m._createEvent("adbreakend"))
+      m._endAdPlayback()
     else if eventType = "ContentPosition"
       ' we have a special case here to track the start of content after an ad break
       if not m._Flag_rssInAdBreak

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1074,6 +1074,16 @@ function muxAnalytics() as Object
     m._emitDeferredContentPlayingAfterAd()
   end sub
 
+  prototype._resetAdPlaybackState = sub()
+    m._Flag_adPlaybackActive = false
+    m._Flag_rafInAdBreak = false
+    m._Flag_deferredContentPlayingAfterAd = false
+    m._Flag_suppressNextContentPlayingAfterAd = false
+    m._Flag_rssInAdBreak = false
+    m._Flag_rssAdEnded = false
+    m._lastAdResumeTime = Invalid
+  end sub
+
   prototype._emitDeferredContentPlayingAfterAd = sub()
     if m._Flag_deferredContentPlayingAfterAd <> true
       return
@@ -2048,6 +2058,7 @@ function muxAnalytics() as Object
     end if
     if m._clientOperatedStartAndEnd = true AND setByClient = false then return
     if m._inView = false
+      m._resetAdPlaybackState()
       m.heartbeatTimer.control = "start"
       m._Flag_heartbeatTimerRunning = true
       m.pollTimer.control = "start"
@@ -2129,6 +2140,7 @@ function muxAnalytics() as Object
 
       m._endPlaybackRange(m._playerPlayheadTime)
       m._addEventToQueue(m._createEvent("viewend"))
+      m._resetAdPlaybackState()
       m._inView = false
       m._viewId = Invalid
       m._viewStartTimestamp = Invalid

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1610,10 +1610,9 @@ function muxAnalytics() as Object
       m._Flag_rafInAdBreak = false
       ' In the case that this is SSAI, we need to signal a play and playing event
       if m._Flag_useSSAI = true
-        hadDeferredContentPlaying = m._Flag_deferredContentPlayingAfterAd = true
+        willEmitDeferredContentPlaying = m._Flag_deferredContentPlayingAfterAd = true AND m.video_state = "playing"
         m._endAdPlayback()
-        emittedDeferredContentPlaying = hadDeferredContentPlaying AND m._Flag_deferredContentPlayingAfterAd <> true
-        if emittedDeferredContentPlaying <> true
+        if willEmitDeferredContentPlaying <> true
           m._Flag_isPaused = false
           m._triggerPlayEvent()
 

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -808,6 +808,7 @@ function muxAnalytics() as Object
     m._Flag_isPaused = (videoState = "paused")
 
     if videoState = "buffering"
+      m._Flag_suppressNextContentPlayingAfterAd = false
       ' Bail out if we aren't supposed to track automatic rebuffer events
       if not m._Flag_automaticRebufferTracking then return
 
@@ -822,6 +823,7 @@ function muxAnalytics() as Object
         end if
       end if
     else if videoState = "paused"
+      m._Flag_suppressNextContentPlayingAfterAd = false
       m._playheadAtLastPause = m._playerPlayheadTime
 
       m._addEventToQueue(m._createEvent("pause"))
@@ -1820,6 +1822,7 @@ function muxAnalytics() as Object
       if not m._Flag_rssInAdBreak
         state = ctx.state
         if state = "buffering"
+          m._Flag_suppressNextContentPlayingAfterAd = false
           ' if m._Flag_isPaused
             m._Flag_isPaused = false
             m._triggerPlayEvent()
@@ -1841,6 +1844,7 @@ function muxAnalytics() as Object
           m._startPlaybackRange(m._playerPlayheadTime)
           m._addEventToQueue(m._createEvent("playing"))
         else if state = "paused"
+          m._Flag_suppressNextContentPlayingAfterAd = false
           m._Flag_isPaused = true
           m._addEventToQueue(m._createEvent("pause"))
         end if

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -585,6 +585,7 @@ function muxAnalytics() as Object
     m._Flag_adPlaybackActive = false
     m._Flag_rafInAdBreak = false
     m._Flag_deferredContentPlayingAfterAd = false
+    m._Flag_suppressNextContentPlayingAfterAd = false
 
     ' Flags specifically for when renderStitchedStream is used
     m._Flag_useRenderStitchedStream = false
@@ -866,6 +867,9 @@ function muxAnalytics() as Object
       end if
       if m._isAdPlaybackActive()
         m._Flag_deferredContentPlayingAfterAd = true
+      else if m._Flag_suppressNextContentPlayingAfterAd = true
+        m._Flag_suppressNextContentPlayingAfterAd = false
+        m._Flag_deferredContentPlayingAfterAd = false
       else
         m._Flag_deferredContentPlayingAfterAd = false
         if m._Flag_lastVideoState = "paused"
@@ -1076,15 +1080,14 @@ function muxAnalytics() as Object
       return
     end if
 
-    currentVideoState = m.video_state
-    if m.video <> Invalid AND m.video.state <> Invalid
-      currentVideoState = m.video.state
-    end if
-    if currentVideoState <> "playing"
+    if m.video_state <> "playing"
+      m._Flag_deferredContentPlayingAfterAd = false
       return
     end if
 
     m._Flag_deferredContentPlayingAfterAd = false
+    m._Flag_suppressNextContentPlayingAfterAd = true
+    m._Flag_isPaused = false
     m._triggerPlayEvent()
     m._emitContentPlayingEvent()
   end sub
@@ -1822,6 +1825,11 @@ function muxAnalytics() as Object
             m._triggerPlayEvent()
           ' end if
         else if state = "playing"
+          if m._Flag_suppressNextContentPlayingAfterAd = true
+            m._Flag_suppressNextContentPlayingAfterAd = false
+            return
+          end if
+
           ' We get the playing event after buffering on initial startup, but
           ' also again on unpausing (without the buffering event), so we need
           ' to send play if we're currently paused

--- a/test/source_tests/source/tests/Test__RAFHandling.brs
+++ b/test/source_tests/source/tests/Test__RAFHandling.brs
@@ -75,6 +75,10 @@ Function TestCase__MuxAnalytics_RAFHandling_StandardAdComplete() as String
   m._resetSUT()
 
   m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
   m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
@@ -82,13 +86,21 @@ Function TestCase__MuxAnalytics_RAFHandling_StandardAdComplete() as String
   m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
-  return m.assertEqual(5100.0#, m.SUT._totalAdWatchTime)
+  m.SUT._testTimeMs = 6200
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  return m.assertEqual(5000.0#, m.SUT._totalAdWatchTime)
 End Function
 
 Function TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingDuringActiveAd() as String
   m._resetSUT()
 
   m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
   m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
@@ -103,15 +115,23 @@ Function TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingDuringActive
   m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
+  m.SUT._testTimeMs = 19100
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
   events = m._eventNames()
 
-  return m.assertEqual("playbackmodechange,networkchange,viewstart,adplay,adplaying,adfirstquartile,adended,play,playing,", events)
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adfirstquartile,adended,adbreakend,play,playing,", events)
 End Function
 
 Function TestCase__MuxAnalytics_RAFHandling_DeferredResumeUsesObservedVideoState() as String
   m._resetSUT()
 
   m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
   m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
@@ -123,15 +143,23 @@ Function TestCase__MuxAnalytics_RAFHandling_DeferredResumeUsesObservedVideoState
   m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
+  m.SUT._testTimeMs = 19100
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
   events = m._eventNames()
 
-  return m.assertEqual("playbackmodechange,networkchange,viewstart,adplay,adplaying,adended,play,playing,", events)
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adbreakend,play,playing,", events)
 End Function
 
 Function TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd() as String
   m._resetSUT()
 
   m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
   m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
@@ -139,12 +167,16 @@ Function TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd() as String
   m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
+  m.SUT._testTimeMs = 19100
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
   m.SUT._testTimeMs = 19700
   m.SUT.videoStateChangeHandler(m._roString("playing"))
 
   events = m._eventNames()
 
-  return m.assertEqual("playbackmodechange,networkchange,viewstart,adplay,adplaying,adended,playing,", events)
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adbreakend,playing,", events)
 End Function
 
 Function TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingBetweenAdsInPod() as String

--- a/test/source_tests/source/tests/Test__RAFHandling.brs
+++ b/test/source_tests/source/tests/Test__RAFHandling.brs
@@ -5,33 +5,203 @@ Function TestSuite__RAFHandling() as Object
   this.SetUp = RAFHandling_SetUp
   this.TearDown = RAFHandling_TearDown
 
-  ' this.addTest("RAFHandling 1", TestCase__MuxAnalytics_RAFHandling)
+  this.addTest("RAFHandling standard ad accumulates watch time on complete", TestCase__MuxAnalytics_RAFHandling_StandardAdComplete)
+  this.addTest("RAFHandling suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingDuringActiveAd)
+  this.addTest("RAFHandling suppresses content playing between ads in pod", TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingBetweenAdsInPod)
+  this.addTest("RAFHandling lets content playing through after ad end", TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd)
+  this.addTest("RAFHandling render stitched suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd)
+  this.addTest("RAFHandling SSAI pod complete does not duplicate deferred resume", TestCase__MuxAnalytics_RAFHandling_SSAIPodCompleteDoesNotDuplicateDeferredResume)
 
   return this
 End Function
 
 Sub RAFHandling_SetUp()
   m.fakeRAFEvent = FakeRAFEvent()
-  m.SUT = MuxAnalytics()
+  m.fakeTimer = FakeTimer()
+  m.fakePort = FakePort()
+  m.fakeAppInfo = FakeAppInfo()
+  m.fakeAppConfig = {
+    MAX_BEACON_SIZE: 10
+    MAX_QUEUE_LENGTH: 100
+    MAX_VIDEO_POSITION_JUMP: 1500
+    HTTP_RETRIES: 1
+    BASE_TIME_BETWEEN_BEACONS: 1000
+    HEARTBEAT_INTERVAL: 10
+    POSITION_TIMER_INTERVAL: 1
+    SEEK_THRESHOLD: 1500
+    USE_RANDOM_MUX_VIEWER_ID: false
+  }
+  m.fakeCustomerConfig = {
+    property_key: "UNIT_TEST_PROPERTY_KEY"
+  }
+  m._resetSUT = sub()
+    m.SUT = MuxAnalytics()
+    m.SUT.heartbeatTimer = FakeTimer()
+    m.SUT.video = FakeVideo()
+    m.SUT._testTimeMs = 0
+    m.SUT._getDateTime = function() as Object
+      faker = FakeDateTime()
+      faker._GetAsSecondsToReturn = Int(m._testTimeMs / 1000)
+      faker._GetMillisecondseToReturn = m._testTimeMs MOD 1000
+      return faker
+    end function
+    m.SUT.init(m.fakeAppInfo, m.fakeAppConfig, m.fakeCustomerConfig, m.fakeTimer, m.fakeTimer, m.fakePort)
+    m.SUT._eventQueue = []
+    m.SUT.videoViewChangeHandler("start")
+  end sub
+  m._eventNames = function() as String
+    events = ""
+    for i = 0 To m.SUT._eventQueue.count() - 1 Step 1
+      events += m.SUT._eventQueue[i].event + ","
+    end for
+    return events
+  end function
+  m._roString = function(value as String) as Object
+    boxedValue = CreateObject("roString")
+    boxedValue.SetString(value)
+    return boxedValue
+  end function
+  m._resetSUT()
 End Sub
 
 Sub RAFHandling_TearDown()
 End Sub
 
-Function TestCase__MuxAnalytics_RAFHandling() as String
-  ' GIVEN
-  ' m.SUT._eventQueue = []
-  ' m.SUT._Flag_seekSentPlayingNotYetStarted = false
-  ' m.SUT._Flag_atLeastOnePlayEventForContent = true
-  ' m.fakeSGNodeEvent._dataToReturn = "buffering"
-  m.fakeRAFEvent._dataToReturn = {king:"kong", eventType:"PodStart"}
-  ' WHEN
+Function TestCase__MuxAnalytics_RAFHandling_StandardAdComplete() as String
+  m._resetSUT()
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
-  ' END
-  return m.assertEqual("rebufferstart", m.SUT._eventQueue[0].e)
+
+  m.SUT._testTimeMs = 6100
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  return m.assertEqual(5100.0#, m.SUT._totalAdWatchTime)
 End Function
 
+Function TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingDuringActiveAd() as String
+  m._resetSUT()
 
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
 
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
 
+  m.SUT._testTimeMs = 6100
+  m.fakeRAFEvent._dataToReturn = {eventType: "FirstQuartile", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
 
+  m.SUT._testTimeMs = 19000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adplay,adplaying,adfirstquartile,adended,play,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd() as String
+  m._resetSUT()
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 19000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 19700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adplay,adplaying,adended,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingBetweenAdsInPod() as String
+  m._resetSUT()
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 6100
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 7000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 12000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 12100
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adplay,adplaying,adended,adbreakend,play,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd() as String
+  m._resetSUT()
+  m.SUT.useRenderStitchedStreamHandler(true)
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "AdStateChange", obj: {}, ctx: {state: "buffering"}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
+  m.fakeRAFEvent._dataToReturn = {eventType: "AdStateChange", obj: {}, ctx: {state: "playing"}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 19000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 19100
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adbreakend,play,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_SSAIPodCompleteDoesNotDuplicateDeferredResume() as String
+  m._resetSUT()
+  m.SUT.useSSAIHandler(true)
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 19000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adbreakend,play,playing,", events)
+End Function

--- a/test/source_tests/source/tests/Test__RAFHandling.brs
+++ b/test/source_tests/source/tests/Test__RAFHandling.brs
@@ -14,6 +14,7 @@ Function TestSuite__RAFHandling() as Object
   this.addTest("RAFHandling render stitched suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd)
   this.addTest("RAFHandling render stitched does not duplicate deferred resume", TestCase__MuxAnalytics_RAFHandling_RenderStitchedDoesNotDuplicateDeferredResume)
   this.addTest("RAFHandling SSAI pod complete does not duplicate deferred resume", TestCase__MuxAnalytics_RAFHandling_SSAIPodCompleteDoesNotDuplicateDeferredResume)
+  this.addTest("RAFHandling SSAI pod complete fallback emits when deferred resume skipped", TestCase__MuxAnalytics_RAFHandling_SSAIPodCompleteFallbackEmitsWhenDeferredResumeSkipped)
 
   return this
 End Function
@@ -284,6 +285,26 @@ Function TestCase__MuxAnalytics_RAFHandling_SSAIPodCompleteDoesNotDuplicateDefer
 
   m.SUT._testTimeMs = 1700
   m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 19000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adbreakend,play,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_SSAIPodCompleteFallbackEmitsWhenDeferredResumeSkipped() as String
+  m._resetSUT()
+  m.SUT.useSSAIHandler(true)
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._Flag_deferredContentPlayingAfterAd = true
+  m.SUT.video_state = "buffering"
 
   m.SUT._testTimeMs = 19000
   m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}

--- a/test/source_tests/source/tests/Test__RAFHandling.brs
+++ b/test/source_tests/source/tests/Test__RAFHandling.brs
@@ -10,6 +10,8 @@ Function TestSuite__RAFHandling() as Object
   this.addTest("RAFHandling deferred resume uses observed video state", TestCase__MuxAnalytics_RAFHandling_DeferredResumeUsesObservedVideoState)
   this.addTest("RAFHandling suppresses content playing between ads in pod", TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingBetweenAdsInPod)
   this.addTest("RAFHandling pause resume after deferred resume emits play and playing", TestCase__MuxAnalytics_RAFHandling_PauseResumeAfterDeferredResumeEmitsPlayPlaying)
+  this.addTest("RAFHandling clears deferred resume suppression across views", TestCase__MuxAnalytics_RAFHandling_ClearsDeferredResumeSuppressionAcrossViews)
+  this.addTest("RAFHandling missing pod complete does not suppress next view", TestCase__MuxAnalytics_RAFHandling_MissingPodCompleteDoesNotSuppressNextView)
   this.addTest("RAFHandling lets content playing through after ad end", TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd)
   this.addTest("RAFHandling render stitched suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd)
   this.addTest("RAFHandling render stitched does not duplicate deferred resume", TestCase__MuxAnalytics_RAFHandling_RenderStitchedDoesNotDuplicateDeferredResume)
@@ -245,6 +247,51 @@ Function TestCase__MuxAnalytics_RAFHandling_PauseResumeAfterDeferredResumeEmitsP
   events = m._eventNames()
 
   return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adbreakend,play,playing,pause,play,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_ClearsDeferredResumeSuppressionAcrossViews() as String
+  m._resetSUT()
+
+  m.SUT._Flag_suppressNextContentPlayingAfterAd = true
+
+  m.SUT.videoViewChangeHandler("end")
+  m.SUT.videoViewChangeHandler("start")
+  m.SUT._eventQueue = []
+
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  events = m._eventNames()
+
+  return m.assertEqual("playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_MissingPodCompleteDoesNotSuppressNextView() as String
+  m._resetSUT()
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 6100
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT.videoViewChangeHandler("end")
+  m.SUT.videoViewChangeHandler("start")
+  m.SUT._eventQueue = []
+
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  events = m._eventNames()
+
+  return m.assertEqual("playing,", events)
 End Function
 
 Function TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd() as String

--- a/test/source_tests/source/tests/Test__RAFHandling.brs
+++ b/test/source_tests/source/tests/Test__RAFHandling.brs
@@ -9,6 +9,7 @@ Function TestSuite__RAFHandling() as Object
   this.addTest("RAFHandling suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingDuringActiveAd)
   this.addTest("RAFHandling deferred resume uses observed video state", TestCase__MuxAnalytics_RAFHandling_DeferredResumeUsesObservedVideoState)
   this.addTest("RAFHandling suppresses content playing between ads in pod", TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingBetweenAdsInPod)
+  this.addTest("RAFHandling pause resume after deferred resume emits play and playing", TestCase__MuxAnalytics_RAFHandling_PauseResumeAfterDeferredResumeEmitsPlayPlaying)
   this.addTest("RAFHandling lets content playing through after ad end", TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd)
   this.addTest("RAFHandling render stitched suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd)
   this.addTest("RAFHandling render stitched does not duplicate deferred resume", TestCase__MuxAnalytics_RAFHandling_RenderStitchedDoesNotDuplicateDeferredResume)
@@ -178,6 +179,39 @@ Function TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingBetweenAdsIn
   events = m._eventNames()
 
   return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adplay,adplaying,adended,adbreakend,play,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_PauseResumeAfterDeferredResumeEmitsPlayPlaying() as String
+  m._resetSUT()
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodStart", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 6100
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 6200
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 20000
+  m.SUT.videoStateChangeHandler(m._roString("paused"))
+
+  m.SUT._testTimeMs = 25000
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adbreakend,play,playing,pause,play,playing,", events)
 End Function
 
 Function TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd() as String

--- a/test/source_tests/source/tests/Test__RAFHandling.brs
+++ b/test/source_tests/source/tests/Test__RAFHandling.brs
@@ -7,9 +7,11 @@ Function TestSuite__RAFHandling() as Object
 
   this.addTest("RAFHandling standard ad accumulates watch time on complete", TestCase__MuxAnalytics_RAFHandling_StandardAdComplete)
   this.addTest("RAFHandling suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingDuringActiveAd)
+  this.addTest("RAFHandling deferred resume uses observed video state", TestCase__MuxAnalytics_RAFHandling_DeferredResumeUsesObservedVideoState)
   this.addTest("RAFHandling suppresses content playing between ads in pod", TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingBetweenAdsInPod)
   this.addTest("RAFHandling lets content playing through after ad end", TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd)
   this.addTest("RAFHandling render stitched suppresses content playing during active ad", TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayingDuringActiveAd)
+  this.addTest("RAFHandling render stitched does not duplicate deferred resume", TestCase__MuxAnalytics_RAFHandling_RenderStitchedDoesNotDuplicateDeferredResume)
   this.addTest("RAFHandling SSAI pod complete does not duplicate deferred resume", TestCase__MuxAnalytics_RAFHandling_SSAIPodCompleteDoesNotDuplicateDeferredResume)
 
   return this
@@ -104,6 +106,26 @@ Function TestCase__MuxAnalytics_RAFHandling_SuppressesContentPlayingDuringActive
   return m.assertEqual("playbackmodechange,networkchange,viewstart,adplay,adplaying,adfirstquartile,adended,play,playing,", events)
 End Function
 
+Function TestCase__MuxAnalytics_RAFHandling_DeferredResumeUsesObservedVideoState() as String
+  m._resetSUT()
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Start", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT.video.state = "buffering"
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 19000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adplay,adplaying,adended,play,playing,", events)
+End Function
+
 Function TestCase__MuxAnalytics_RAFHandling_ContentPlayingAfterAdEnd() as String
   m._resetSUT()
 
@@ -179,6 +201,38 @@ Function TestCase__MuxAnalytics_RAFHandling_RenderStitchedSuppressesContentPlayi
 
   m.SUT._testTimeMs = 19100
   m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  events = m._eventNames()
+
+  return m.assertEqual("playbackmodechange,networkchange,viewstart,adbreakstart,adplay,adplaying,adended,adbreakend,play,playing,", events)
+End Function
+
+Function TestCase__MuxAnalytics_RAFHandling_RenderStitchedDoesNotDuplicateDeferredResume() as String
+  m._resetSUT()
+  m.SUT.useRenderStitchedStreamHandler(true)
+
+  m.SUT._testTimeMs = 1000
+  m.fakeRAFEvent._dataToReturn = {eventType: "AdStateChange", obj: {}, ctx: {state: "buffering"}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1100
+  m.fakeRAFEvent._dataToReturn = {eventType: "AdStateChange", obj: {}, ctx: {state: "playing"}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 1700
+  m.SUT.videoStateChangeHandler(m._roString("playing"))
+
+  m.SUT._testTimeMs = 19000
+  m.fakeRAFEvent._dataToReturn = {eventType: "Complete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 19100
+  m.fakeRAFEvent._dataToReturn = {eventType: "PodComplete", obj: {}, ctx: {}}
+  m.SUT.rafEventHandler(m.fakeRAFEvent)
+
+  m.SUT._testTimeMs = 19200
+  m.fakeRAFEvent._dataToReturn = {eventType: "ContentStateChange", obj: {}, ctx: {state: "playing"}}
   m.SUT.rafEventHandler(m.fakeRAFEvent)
 
   events = m._eventNames()


### PR DESCRIPTION
[NAT-435]

## Summary

Roku ads could appear as <=1s when the SDK emitted content `play` / `playing` while an ad was still active.

Mux Data treats playback events during an active ad as ending the ad segment, so this change suppresses content `play` / `playing` during ad playback and emits the deferred content resume after the ad ends.

## Changes

- Track active ad playback across Roku ad callbacks, server-side ads, and render-stitched ad flows.
- Suppress content `play` / `playing` while ads are active.
- Emit deferred content resume after ad end when video is still playing.
- Add tests for suppression, resume, server-side ads, and render-stitched behavior.

## Validation

- Focused ad tests pass.
- Roku dashboard confirmation:
  - normal flow: ~10s ad
  - simulated broken flow: ~10s ad instead of ~0.7s

[NAT-435]: https://mux1.atlassian.net/browse/NAT-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when content play/playing beacons fire across ad modes (CSAI, SSAI, render-stitched), which directly affects view/ad timing metrics; mitigated by extensive new RAF handling tests.
> 
> **Overview**
> Fixes **incorrectly short ad durations** in Mux Data when the Roku player reports content `playing` while RAF ads are still active.
> 
> The SDK now tracks **active ad playback** (standard RAF, SSAI, and render-stitched flows) and **blocks content `play` / `playing`** until the ad segment ends. Deferred resume emits those events after `PodComplete` / ad end when the video node is still `playing`, with a one-shot suppress flag to avoid duplicate `playing` from follow-on `ContentStateChange` or mid-pod transitions.
> 
> **`videoStateChangeHandler`** routes content playback through `_triggerPlayEvent` / `_emitContentPlayingEvent` instead of enqueueing `play`/`playing` directly. **View start/end** resets ad/deferral flags so suppression does not leak across views.
> 
> Adds a broad **`Test__RAFHandling`** suite covering suppression, deferred resume, multi-ad pods, SSAI/render-stitched edge cases, and cross-view cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd99ab4e945ce8348739b591ee1b051b361a8f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->