### PR TITLE
Release v2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "./src/mux-analytics.brs",
   "dependencies": {
     "@rokucommunity/bslint": "^0.8.9",

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "2.7.0"
+  m.MUX_SDK_VERSION = "2.7.1"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
   


### PR DESCRIPTION
## Summary
- bump SDK version from 2.7.0 to 2.7.1 in package.json and mux-analytics.brs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no logic or behavior modifications.
> 
> **Overview**
> Bumps the Roku Mux SDK release from **2.7.0** to **2.7.1** in `package.json` and sets `m.MUX_SDK_VERSION` to the same value in `src/mux-analytics.brs`, so npm metadata and analytics session properties (`player_mux_plugin_version`) stay aligned for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6429abf256d87d315f82bb98ea83bfa12ff2ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->