### PR TITLE
NAT-424: audiotrackchange events

### DIFF
--- a/sampleapp_source/components_reset/components/PlayerTask.brs
+++ b/sampleapp_source/components_reset/components/PlayerTask.brs
@@ -119,6 +119,14 @@ sub playContent()
     contentInfo.contentId = "Becoming You"
     m.top.video.content = contentNode
     PlayContentOnlyNoAds(contentInfo)
+  else if selectionId = "audiotracks"
+    ' Multi-language audio (English + Français)
+    contentNode.URL = "https://stream.mux.com/3x5wDUHxkd8NkEfspLUK3OpSQEJe3pom.m3u8"
+    contentNode.StreamFormat = "hls"
+    contentInfo.length = 16
+    contentInfo.contentId = "Multi-language audio"
+    m.top.video.content = contentNode
+    PlayContentOnlyNoAds(contentInfo)
   else if selectionId = "playlist"
     createPlaylist()
     PlayContentOnlyNoAds(contentInfo)

--- a/sampleapp_source/components_reset/components/PlayerTask.brs
+++ b/sampleapp_source/components_reset/components/PlayerTask.brs
@@ -115,6 +115,7 @@ sub playContent()
   else if selectionId = "texttracks"
     contentNode.URL = "https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8"
     contentNode.StreamFormat = "hls"
+    contentNode.TITLE = "Becoming You — Official Trailer"
     contentInfo.length = 98
     contentInfo.contentId = "Becoming You"
     m.top.video.content = contentNode
@@ -123,6 +124,7 @@ sub playContent()
     ' Multi-language audio (English + Français)
     contentNode.URL = "https://stream.mux.com/3x5wDUHxkd8NkEfspLUK3OpSQEJe3pom.m3u8"
     contentNode.StreamFormat = "hls"
+    contentNode.TITLE = "Multi-language audio"
     contentInfo.length = 16
     contentInfo.contentId = "Multi-language audio"
     m.top.video.content = contentNode

--- a/sampleapp_source/components_reset/components/VideoScene.brs
+++ b/sampleapp_source/components_reset/components/VideoScene.brs
@@ -34,7 +34,8 @@ sub setupContent()
   {title: "Playlist content, no ads", selectionID: "playlist"},
   {title: "Live stream", selectionID: "live"},
   {title: "TEST: View Transition Race", selectionID: "test_race"},
-  {title: "Subtitle/CC", selectionID: "texttracks"}
+  {title: "Subtitle/CC", selectionID: "texttracks"},
+  {title: "Audio Tracks", selectionID: "audiotracks"}
   ]
 
   listContent = createObject("roSGNode","ContentNode")

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -959,6 +959,11 @@ function muxAnalytics() as Object
   ' examine the current presented text track state and potentially send a texttrackchange event
   prototype._checkTextTrackState = sub(_ = Invalid)
     if m._viewId = Invalid then return
+    ' values may be stale/inconsistent in these states:
+    playbackState = m._getObservedVideoNodeField("state")
+    if playbackState = Invalid or playbackState = "none" or playbackState = "buffering" or playbackState = "error"
+      return
+    end if
 
     state = m._createTextTrackChangeState()
     if state = Invalid then return
@@ -999,12 +1004,6 @@ function muxAnalytics() as Object
 
     trackId = m._getObservedVideoNodeField("currentSubtitleTrack")
     if trackId = Invalid or trackId = ""
-      ' Do not trust these empty values during error state or initial buffering...
-      state = m._getObservedVideoNodeField("state")
-      if state = Invalid or state = "none" or state = "buffering" or state = "error"
-        return Invalid
-      end if
-      ' ...but after that, this means no available track:
       return { presentedSubtitleTrack: Invalid }
     end if
 
@@ -1017,10 +1016,10 @@ function muxAnalytics() as Object
       return { player_text_track_enabled: false }
     end if
 
-    tracks = m._getObservedVideoNodeField("availableSubtitleTracks")
-    if tracks = Invalid then return Invalid
-
     props = { player_text_track_enabled: true }
+
+    tracks = m._getObservedVideoNodeField("availableSubtitleTracks")
+    if tracks = Invalid then tracks = []
 
     for each track in tracks
       if track.TrackName = trackId
@@ -1030,15 +1029,9 @@ function muxAnalytics() as Object
         if track.Language <> Invalid and track.Language <> ""
           props.player_text_track_language = track.Language
         end if
-        return props
+        exit for
       end if
     end for
-
-    ' not found, track list may be loading...
-    state = m._getObservedVideoNodeField("state")
-    if state = Invalid or state = "none" or state = "buffering"
-      return Invalid
-    end if
 
     return props
   end function
@@ -1046,6 +1039,11 @@ function muxAnalytics() as Object
   ' examine the current playing audio track and potentially send an audiotrackchange event
   prototype._checkAudioTrackState = sub(_ = Invalid)
     if m._viewId = Invalid then return
+    ' values may be stale/inconsistent in these states:
+    playbackState = m._getObservedVideoNodeField("state")
+    if playbackState = Invalid or playbackState = "none" or playbackState = "buffering" or playbackState = "error"
+      return
+    end if
 
     state = m._createAudioTrackChangeState()
     if state = Invalid then return
@@ -1069,12 +1067,6 @@ function muxAnalytics() as Object
   prototype._createAudioTrackChangeState = function() as Object
     trackId = m._getObservedVideoNodeField("currentAudioTrack")
     if trackId = Invalid or trackId = ""
-      ' Do not trust these empty values during error state or initial buffering...
-      state = m._getObservedVideoNodeField("state")
-      if state = Invalid or state = "none" or state = "buffering" or state = "error"
-        return Invalid
-      end if
-      ' ...but after that, this means no audio track:
       return { presentedAudioTrack: Invalid }
     end if
 
@@ -1087,12 +1079,11 @@ function muxAnalytics() as Object
       return { player_audio_track_enabled: false }
     end if
 
-    tracks = m._getObservedVideoNodeField("availableAudioTracks")
-    if tracks = Invalid then return Invalid
-
     props = { player_audio_track_enabled: true }
 
-    foundTrack = false
+    tracks = m._getObservedVideoNodeField("availableAudioTracks")
+    if tracks = Invalid then tracks = []
+
     for each track in tracks
       if track.Track = trackId
         if track.Name <> Invalid and track.Name <> ""
@@ -1101,18 +1092,9 @@ function muxAnalytics() as Object
         if track.Language <> Invalid and track.Language <> ""
           props.player_audio_track_language = track.Language
         end if
-        foundTrack = true
         exit for
       end if
     end for
-
-    if not foundTrack
-      ' not found, track list may be loading...
-      state = m._getObservedVideoNodeField("state")
-      if state = Invalid or state = "none" or state = "buffering"
-        return Invalid
-      end if
-    end if
 
     ' best-effort codec from the currently playing audio format
     audioFormat = m._getObservedVideoNodeField("audioFormat")

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -957,7 +957,7 @@ function muxAnalytics() as Object
   end sub
 
   ' examine the current presented text track state and potentially send a texttrackchange event
-  prototype._checkTextTrackState = sub(ignored = Invalid)
+  prototype._checkTextTrackState = sub(_ = Invalid)
     if m._viewId = Invalid then return
 
     state = m._createTextTrackChangeState()
@@ -1044,7 +1044,7 @@ function muxAnalytics() as Object
   end function
 
   ' examine the current playing audio track and potentially send an audiotrackchange event
-  prototype._checkAudioTrackState = sub(ignored = Invalid)
+  prototype._checkAudioTrackState = sub(_ = Invalid)
     if m._viewId = Invalid then return
 
     state = m._createAudioTrackChangeState()

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -613,6 +613,9 @@ function muxAnalytics() as Object
     ' Text Track Changes
     m._textTrackChangesState = Invalid
 
+    ' Audio Track Changes
+    m._audioTrackChangesState = Invalid
+
     ' kick off analytics
     date = m._getDateTime()
     m._startTimestamp = 0# + date.AsSeconds() * 1000.0#  + date.GetMilliseconds()
@@ -700,12 +703,20 @@ function muxAnalytics() as Object
     ' check refreshed state(s)
     ' note: to preserve behavior, videoStateChangeHandler is not called until first "state" change message.
     m._checkTextTrackState()
+    m._checkAudioTrackState()
   end sub
 
-  ' registry of handler names for observed video node fields
+  ' registry of handler names for observed video node fields (keys ordered alphabetically)
   prototype._videoNodeFieldChangeHandlers = {
+    "audioFormat": [],
+    "availableAudioTracks": [
+      "_checkAudioTrackState",
+    ],
     "availableSubtitleTracks": [
       "_checkTextTrackState",
+    ],
+    "currentAudioTrack": [
+      "_checkAudioTrackState",
     ],
     "currentSubtitleTrack": [
       "_checkTextTrackState",
@@ -719,6 +730,7 @@ function muxAnalytics() as Object
     "state": [
       "videoStateChangeHandler",
       "_checkTextTrackState",
+      "_checkAudioTrackState",
     ]
   }
 
@@ -1026,6 +1038,86 @@ function muxAnalytics() as Object
     state = m._getObservedVideoNodeField("state")
     if state = Invalid or state = "none" or state = "buffering"
       return Invalid
+    end if
+
+    return props
+  end function
+
+  ' examine the current playing audio track and potentially send an audiotrackchange event
+  prototype._checkAudioTrackState = sub(ignored = Invalid)
+    if m._viewId = Invalid then return
+
+    state = m._createAudioTrackChangeState()
+    if state = Invalid then return
+
+    oldState = m._audioTrackChangesState
+    if oldState <> Invalid and oldState.presentedAudioTrack = state.presentedAudioTrack
+      if oldState.hasSentEvent = true then return
+      state = oldState
+    else
+      m._audioTrackChangesState = state
+    end if
+
+    props = m._createAudioTrackChangeEventProps(state.presentedAudioTrack)
+    if props = Invalid then return
+
+    state.hasSentEvent = true
+    m._addEventToQueue(m._createEvent("audiotrackchange", props))
+  end sub
+
+  ' return audiotrackchange event state or Invalid if not loaded/ready.
+  prototype._createAudioTrackChangeState = function() as Object
+    trackId = m._getObservedVideoNodeField("currentAudioTrack")
+    if trackId = Invalid or trackId = ""
+      ' Do not trust these empty values during error state or initial buffering...
+      state = m._getObservedVideoNodeField("state")
+      if state = Invalid or state = "none" or state = "buffering" or state = "error"
+        return Invalid
+      end if
+      ' ...but after that, this means no audio track:
+      return { presentedAudioTrack: Invalid }
+    end if
+
+    return { presentedAudioTrack: trackId }
+  end function
+
+  ' return audiotrackchange event props based on the provided track or Invalid if not loaded/ready.
+  prototype._createAudioTrackChangeEventProps = function(trackId as Dynamic) as Object
+    if trackId = Invalid or trackId = ""
+      return { player_audio_track_enabled: false }
+    end if
+
+    tracks = m._getObservedVideoNodeField("availableAudioTracks")
+    if tracks = Invalid then return Invalid
+
+    props = { player_audio_track_enabled: true }
+
+    foundTrack = false
+    for each track in tracks
+      if track.Track = trackId
+        if track.Name <> Invalid and track.Name <> ""
+          props.player_audio_track_name = track.Name
+        end if
+        if track.Language <> Invalid and track.Language <> ""
+          props.player_audio_track_language = track.Language
+        end if
+        foundTrack = true
+        exit for
+      end if
+    end for
+
+    if not foundTrack
+      ' not found, track list may be loading...
+      state = m._getObservedVideoNodeField("state")
+      if state = Invalid or state = "none" or state = "buffering"
+        return Invalid
+      end if
+    end if
+
+    ' best-effort codec from the currently playing audio format
+    audioFormat = m._getObservedVideoNodeField("audioFormat")
+    if audioFormat <> Invalid and audioFormat <> "" and audioFormat <> "none" and audioFormat <> "unknown"
+      props.player_audio_track_codec = audioFormat
     end if
 
     return props
@@ -2121,8 +2213,9 @@ function muxAnalytics() as Object
       m._lastConnectionType = initialConnectionType
       m._fireNetworkChangeEvent(initialConnectionType)
 
-      ' fire initial texttrackchange event if ready
+      ' fire an initial change event if ready
       m._checkTextTrackState()
+      m._checkAudioTrackState()
 
       m._addEventToQueue(m._createEvent("viewstart"))
 
@@ -2193,6 +2286,9 @@ function muxAnalytics() as Object
 
       ' Text Track Changes
       m._textTrackChangesState = Invalid
+
+      ' Audio Track Changes
+      m._audioTrackChangesState = Invalid
     end if
   end sub
 

--- a/test/source_tests/source/tests/Test__Minification.brs
+++ b/test/source_tests/source/tests/Test__Minification.brs
@@ -29,6 +29,10 @@ Function TestSuite__Minification() as Object
   this.addTest("Minification [11] player_text_track_type", TestCase__MuxAnalytics_Minification_minifies_player_text_track_type)
   this.addTest("Minification [12] player_text_track_name", TestCase__MuxAnalytics_Minification_minifies_player_text_track_name)
   this.addTest("Minification [13] player_text_track_language", TestCase__MuxAnalytics_Minification_minifies_player_text_track_language)
+  this.addTest("Minification [14] player_audio_track_enabled", TestCase__MuxAnalytics_Minification_minifies_player_audio_track_enabled)
+  this.addTest("Minification [15] player_audio_track_name", TestCase__MuxAnalytics_Minification_minifies_player_audio_track_name)
+  this.addTest("Minification [16] player_audio_track_language", TestCase__MuxAnalytics_Minification_minifies_player_audio_track_language)
+  this.addTest("Minification [17] player_audio_track_codec", TestCase__MuxAnalytics_Minification_minifies_player_audio_track_codec)
 
   return this
 End Function
@@ -280,4 +284,44 @@ Function TestCase__MuxAnalytics_Minification_minifies_player_text_track_language
   result = m.SUT._minify(body)
   ' THEN
   return m.assertEqual(result.keys()[0], "ptetrla")
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_player_audio_track_enabled() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {player_audio_track_enabled: true}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "paotreb")
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_player_audio_track_name() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {player_audio_track_name: "English"}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "paotrnm")
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_player_audio_track_language() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {player_audio_track_language: "eng"}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "paotrla")
+end function
+
+Function TestCase__MuxAnalytics_Minification_minifies_player_audio_track_codec() as String
+  ' GIVEN
+  m.SUT.minification = true
+  body = {player_audio_track_codec: "aac"}
+  ' WHEN
+  result = m.SUT._minify(body)
+  ' THEN
+  return m.assertEqual(result.keys()[0], "paotrcc")
 end function


### PR DESCRIPTION
Implement the audiotrackchange event on the Roku SDK, mirroring the texttrackchange work (NAT-390) and reusing its generic video-node-field observation framework.

- Observe currentAudioTrack (the playing track) and availableAudioTracks; read audioFormat for a best-effort codec (no handler, so a format-only change does not fire an event).
- Emit player_audio_track_enabled / _name / _language / _codec using the audio track AA keys (Track / Name / Language).
- Fire an initial audiotrackchange at view start and on videoAddedHandler.
- Add minification tests for the new dimensions.
- Add an "Audio Tracks" sample-app selection for manual verification.

Also adds a few improvements to text track changes:
- Avoids creating change events during the "buffering" state. Even though we correctly react to changes here, the changed values come in individually while other values are stale.
- Adds a title to the sample app entry so it shows up in dashboards

Resolves [NAT-424].

[NAT-424]: https://mux1.atlassian.net/browse/NAT-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only additions with parallel logic to existing text-track handling; sample app changes are for manual QA only.
> 
> **Overview**
> Adds **`audiotrackchange`** to the Roku Mux SDK, following the same pattern as **`texttrackchange`**.
> 
> The SDK watches **`currentAudioTrack`** and **`availableAudioTracks`**, and reads **`audioFormat`** for codec on each event (format-only changes do not emit). Events include **`player_audio_track_enabled`**, name, language, and codec. An initial event is sent at view start and when the video node is attached; state resets when the view ends.
> 
> **`texttrackchange`** is aligned with the same guard: no events while playback is **`none`** or **`buffering`**, and subtitle props are built without blocking on an empty track list.
> 
> The reset sample app gets an **Audio Tracks** menu entry (multi-language HLS) and a title on the subtitle/CC sample. Minification tests cover the new beacon fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4998ee729550efb6fbee4e0d40227bccc8e9132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->