### PR TITLE
Local API reference agent skill

### DIFF
--- a/.agents/skills/roku-api-reference/SKILL.md
+++ b/.agents/skills/roku-api-reference/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: roku-api-reference
+description: Authoritative reference for Roku SDK APIs and associated developer documentation. Use whenever working with Roku APIs — e.g. SceneGraph node fields (Video, Audio, Task), BrightScript components/ifaces, or verifying a field's name/type/values/availability — instead of relying on training knowledge, which is often stale or wrong for Roku.
+---
+
+# Roku API Reference
+
+Treat the official Roku developer documentation (`rokudev/dev-doc`) as the **source of truth**
+for Roku APIs. Roku's SceneGraph field names, value enums, and OS-version availability are easy
+to get subtly wrong from memory — always confirm against these docs before asserting a fact or
+wiring up a field.
+
+## Local copy
+
+The docs are kept as a shallow clone in a shared machine cache:
+
+```
+~/.cache/roku-dev-doc
+```
+
+Ensure it exists and is current before reading:
+
+```bash
+DOCS="$HOME/.cache/roku-dev-doc"
+if [ -d "$DOCS/.git" ]; then
+  git -C "$DOCS" fetch --depth 1 origin HEAD >/dev/null 2>&1 \
+    && git -C "$DOCS" reset --hard FETCH_HEAD >/dev/null 2>&1 || true
+else
+  mkdir -p "$(dirname "$DOCS")"
+  git clone --depth 1 https://github.com/rokudev/dev-doc.git "$DOCS"
+fi
+```
+
+## Where to look
+
+Reference docs live under `docs/REFERENCES/`:
+
+- `docs/REFERENCES/references-overview.md` — start here for a map of what's documented.
+- `docs/REFERENCES/scenegraph/` — SceneGraph nodes. Media playback fields are in
+  `docs/REFERENCES/scenegraph/media-playback-nodes/` (`video.md`, `audio.md`).
+- `docs/REFERENCES/brightscript/` — BrightScript reference, split into `components/`,
+  `interfaces/`, `events/`, and `language/`.
+- `docs/REFERENCES/deprecated-apis.md` — deprecations.

--- a/.claude/skills/roku-api-reference
+++ b/.claude/skills/roku-api-reference
@@ -1,0 +1,1 @@
+../../.agents/skills/roku-api-reference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Roku API reference
+
+Treat the official Roku developer docs (`rokudev/dev-doc`) as the source of truth for Roku APIs
+(SceneGraph node fields, BrightScript components, value enums, OS-version availability) rather
+than relying on model training knowledge, which is often stale or wrong for Roku.
+
+See the `roku-api-reference` skill in [`.agents/skills/`](.agents/skills/roku-api-reference/SKILL.md)
+for how to clone/refresh the docs cache and where to look. Agents that support the
+`.agents/skills/` convention load it automatically when relevant.


### PR DESCRIPTION
Simple local API reference skill. Helps nudge these coding agents to lean on the docs, and makes it trivial to have plans/implementations verified/validated against them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill wiring only; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds agent-facing guidance so coding assistants **verify Roku APIs against official docs** (`rokudev/dev-doc`) instead of guessing from training data.
> 
> Introduces the **`roku-api-reference`** skill under `.agents/skills/`, including a shell snippet to shallow-clone or refresh `~/.cache/roku-dev-doc` and pointers into `docs/REFERENCES/` (SceneGraph, BrightScript, deprecations). **`AGENTS.md`** summarizes the same policy and links to the skill. A **`.claude/skills/roku-api-reference`** symlink exposes the shared skill to Claude-compatible tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e86ef767762fda6dcc2ea5517c4760cd1f3211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->