### PR TITLE
Release v2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.1",
+  "version": "2.8.0",
   "main": "./src/mux-analytics.brs",
   "dependencies": {
     "@rokucommunity/bslint": "^0.8.9",

--- a/src/mux-analytics.brs
+++ b/src/mux-analytics.brs
@@ -1,5 +1,5 @@
 sub init()
-  m.MUX_SDK_VERSION = "2.7.1"
+  m.MUX_SDK_VERSION = "2.8.0"
   m.top.id = "mux"
   m.top.functionName = "runBeaconLoop"
   


### PR DESCRIPTION
## Summary
- bump SDK version from 2.7.1 to 2.8.0 in package.json and mux-analytics.brs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version string updates; no runtime logic, security, or data-handling changes.
> 
> **Overview**
> **Release v2.8.0** — version-only change with no behavioral or API updates in this diff.
> 
> The npm `version` in `package.json` and `m.MUX_SDK_VERSION` in `src/mux-analytics.brs` are both updated from **2.7.1** to **2.8.0**, keeping the deploy path and the version sent to Mux Data (`player_mux_plugin_version` in session properties) aligned per the release process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dac9182cbacdf068aa38e68abff2ee491afe330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->